### PR TITLE
[FEAT] 21 로그인 퍼블리싱

### DIFF
--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -1,0 +1,11 @@
+interface LayoutProps {
+  children: React.ReactNode
+}
+
+export default function LoginLayout({ children }: LayoutProps) {
+  return (
+    <section className="h-full flex flex-col min-h-[calc(100vh-260px)] items-center justify-center p-14 bg-amber-100">
+      {children}
+    </section>
+  )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,58 @@
+import CheckeBox from "@/app/components/CheckBox";
+import InputBox from "@/app/components/InputBox";
+import TypeRadioInput from "@/app/components/TypeRadioInput";
+import Link from "next/link";
+
+export default function LoginPage() {
+  return (
+    <section className="bg-white w-full p-10 sm:w-160 transition-all">
+      <div className="text-center">
+        <strong>환영합니다</strong>
+        <p className="mbs-2">계정에 로그인하세요</p>
+      </div>
+
+      <form action="" className="mbs-10">
+        {/* 계정 타입 */}
+        <div className="flex gap-2">
+          <TypeRadioInput
+            label="소비자"
+            name="login"
+            value="USER"
+          />
+          <TypeRadioInput
+            label="판매자"
+            name="login"
+            value="BUSINSS"
+          />
+          <TypeRadioInput
+            label="관리자"
+            name="login"
+            value="ADMIN"
+          />
+        </div>
+
+        {/* 아이디 패스워드 */}
+        <div className="flex flex-col gap-5 mbs-8">
+          <InputBox type="text" label="아이디" name="login-id" placeholder="이메일을 입력하세요"/>          
+          <InputBox type="text" label="패스워드" name="login-password" placeholder="비밀번호를 입력하세요"/>          
+        </div>
+
+        {/* 로그인 서브 컨텐츠 */}
+        <div className="flex justify-between mbs-12">
+          <CheckeBox name="login-stay" label="로그인 상태유지" />
+          <Link href="/" className="text-gray-600">비밀번호 재설정</Link>
+        </div>
+
+        {/* 로그인버튼 */}
+        <button type="submit" className="w-full py-4 mbs-4 bg-gray-200 cursor-pointer">로그인 버튼</button>
+      </form>
+
+      {/* 간편로그인 */}
+      <div className="relative border-bs mbs-12">
+        <span className="absolute left-1/2 -translate-1/2 bg-white px-6">간편로그인</span>
+        {/* 카카오로그인 */}
+        <button type="submit" className="w-full py-4 mbs-7 bg-gray-200 cursor-pointer">카카오 로그인</button>
+      </div>
+    </section>
+  )
+}

--- a/src/app/components/CheckBox.tsx
+++ b/src/app/components/CheckBox.tsx
@@ -1,0 +1,27 @@
+import { useId } from "react"
+
+interface CheckProps {
+  label: string
+  name: string
+}
+
+export default function CheckBox({ label, name }: CheckProps) {
+  const uniqueId = useId()
+
+  return (
+     <div className="flex items-center">
+      <input
+        className="border w-5 h-5 appearance-none cursor-pointer checked:bg-black"
+        id={uniqueId}
+        name={name}
+        type="checkbox"
+      />
+      <label
+        htmlFor={uniqueId}
+        className="cursor-pointer ms-2 text-gray-600"
+      >
+        {label}
+      </label>
+    </div>
+  )
+}

--- a/src/app/components/InputBox.tsx
+++ b/src/app/components/InputBox.tsx
@@ -1,0 +1,28 @@
+import { useId } from "react"
+
+interface InputBoxProps {
+  label: string
+  placeholder?: string
+  name: string
+  type?: "text" | "password"
+  value?: string
+  onChange?: () => void
+}
+
+export default function InputBox({ label, placeholder, name, type = "text", value, onChange }: InputBoxProps) {
+  const uniqueId = useId()
+
+  return (
+    <div className="flex flex-col">
+      <label htmlFor={uniqueId}>{label}</label>
+      <input
+        className="border px-3 py-2 mbs-1"
+        id={uniqueId}
+        type={type}
+        placeholder={placeholder}
+        name={name}
+        value={value}
+      />
+    </div>
+  )
+}

--- a/src/app/components/TypeRadioInput.tsx
+++ b/src/app/components/TypeRadioInput.tsx
@@ -1,0 +1,30 @@
+import { useId } from "react"
+
+interface TypeRadioInput {
+  label: string
+  name: string
+  value: string
+  checked?: boolean
+  onChange?: () => void
+}
+
+export default function TypeRadioInput({ label, name }: TypeRadioInput) {
+  const uniqueId = useId()
+
+  return (
+    <div className="border flex-1 cursor-pointer">
+      <input
+        type="radio"
+        className="sr-only peer"
+        id={uniqueId}
+        name={name}
+      />
+      <label
+        htmlFor={uniqueId}
+        className="cursor-pointer block  text-center peer-checked:bg-amber-300 peer-checked:border-blue-600 peer-focus-visible:ring-2 peer-focus-visible:ring-black py-2"
+      >
+        {label}
+      </label>
+    </div>
+  )
+}


### PR DESCRIPTION
### **PR 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [X]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [X]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**
- 로그인 퍼블리싱 작업

### **PR 상세**
- 로그인 레이아웃 작업
- 로그인에 유저 타입 버튼(radio) 추가
- 회원가입/로그인에 사용할 input 컴포넌트 추가
- 약관에 사용할 checkbox 추가
- 현재 간편로그인 버튼은 레이아웃만 잡아두었습니다.
<img width="635" height="1116" alt="image" src="https://github.com/user-attachments/assets/09b10e7d-a329-4cb1-85a6-e4a6c167785c" />


### **이슈번호 # **
#21 