### PR TITLE
[FEAT] 29 비밀번호 재설정 페이지 퍼블리싱

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function LoginPage() {
   return (
-    <section className="bg-white w-full p-10 sm:w-160 transition-all">
+    <div className="bg-white w-full p-10 sm:w-160 transition-all">
       <div className="text-center">
         <strong>환영합니다</strong>
         <p className="mbs-2">계정에 로그인하세요</p>
@@ -53,6 +53,6 @@ export default function LoginPage() {
         {/* 카카오로그인 */}
         <button type="submit" className="w-full py-4 mbs-7 bg-gray-200 cursor-pointer">카카오 로그인</button>
       </div>
-    </section>
+    </div>
   )
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -40,7 +40,7 @@ export default function LoginPage() {
         {/* 로그인 서브 */}
         <div className="flex justify-between mbs-12">
           <CheckeBox name="login-stay" label="로그인 상태유지" />
-          <Link href="/" className="text-gray-600">비밀번호 재설정</Link>
+          <Link href="/reset-password-check" className="text-gray-600">비밀번호 재설정</Link>
         </div>
 
         {/* 로그인버튼 */}

--- a/src/app/(auth)/reset-password-check/layout.tsx
+++ b/src/app/(auth)/reset-password-check/layout.tsx
@@ -1,0 +1,11 @@
+interface ResetPasswordCheckProps {
+  children: string
+}
+
+export default function ResetPasswordCheckLayout({ children }: ResetPasswordCheckProps) {
+  return (
+    <section className="h-full flex flex-col min-h-[calc(100vh-260px)] items-center justify-center p-14 bg-amber-100">
+      {children}
+    </section>
+  )
+}

--- a/src/app/(auth)/reset-password-check/page.tsx
+++ b/src/app/(auth)/reset-password-check/page.tsx
@@ -1,0 +1,29 @@
+import InputBox from "@/app/components/InputBox"
+import Link from "next/link"
+
+interface ResetPasswordCheckProps {
+  children: string
+}
+
+export default function ResetPasswordCheckPage({ children }: ResetPasswordCheckProps) {
+  return (
+    <div className="bg-white w-full p-10 sm:w-160 transition-all">
+      <div>
+        <strong>비밀번호 재설정</strong>
+      </div>
+
+      <form action="" className="mbs-10">
+        <div className="flex flex-col gap-2">
+          <InputBox type="text" label="이름" name="find-id" placeholder="이름을 입력하세요"/>
+          <InputBox type="text" label="이메일" name="find-email" placeholder="이메일을 입력하세요"/>
+          <InputBox type="text" label="핸드폰 번호" name="find-email" placeholder="핸드폰 번호를 입력하세요"/>
+        </div>
+        <p className="mbs-2 text-center text-red-500 invisible">입력하신 정보로 가입 된 회원은 존재하지 않습니다.</p>
+
+        {/* 실제 사용은 button으로 사용예정 연결확인을 위해 Link로 임시 연결*/}
+        <Link href="/reset-password" className="block text-center w-full py-4 mbs-8 bg-gray-200 cursor-pointer">확인</Link>
+        {/* <button type="submit" className="w-full py-4 mbs-8 bg-gray-200 cursor-pointer">확인</button> */}
+      </form>
+    </div>
+  )
+}

--- a/src/app/(auth)/reset-password/layout.tsx
+++ b/src/app/(auth)/reset-password/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react"
+
+interface ResetPasswordProps {
+  children: ReactNode
+}
+
+export default function ResetPasswordLayout({ children }: ResetPasswordProps) {
+  return (
+    <section className="h-full flex flex-col min-h-[calc(100vh-260px)] items-center justify-center p-14 bg-amber-100">
+      {children}
+    </section>
+  )
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,21 @@
+import InputBox from "@/app/components/InputBox";
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="bg-white w-full p-10 sm:w-160 transition-all">
+      <div>
+        <strong>비밀번호 재설정</strong>
+      </div>
+
+      <form action="">
+        <div className="flex flex-col gap-5 mbs-8">
+          <InputBox type="password" label="비밀번호 입력" name="reset-password" placeholder="비밀번호를 입력하세요"/>          
+          <InputBox type="password" label="비밀번호 재입력" name="reset-check-password" placeholder="비밀번호를 재입력하세요"/>          
+        </div>
+        <p className="mbs-2 text-center text-red-500 invisible">비밀번호가 동일하지 않습니다.</p>
+
+        <button type="submit" className="w-full py-4 mbs-8 bg-gray-200 cursor-pointer">메인페이지로 이동</button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -5,7 +5,7 @@ import TypeRadioInput from "@/app/components/TypeRadioInput";
 export default function SignupPage() {
   return (
     <>
-      <section className="bg-white w-full p-10 sm:w-160 transition-all">
+      <div className="bg-white w-full p-10 sm:w-160 transition-all">
         <div className="text-lg">
           <strong>회원가입</strong>
         </div>
@@ -41,7 +41,7 @@ export default function SignupPage() {
           <button type="submit" className="w-full py-4 mbs-4 bg-black text-white cursor-pointer">회원가입</button>
         </form>
 
-      </section>
+      </div>
       <strong className="mbs-4 text-red-600 text-center">현 사이트는 실제로 운영되는 페이지가 아닙니다.<br />개인정보를 넣지 말아주세요</strong>
     </>
   )


### PR DESCRIPTION
### **PR 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [X]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**

- 유저 본인 확인 페이지 퍼블리싱
- 비밀번호 재설정 페이지 퍼블리싱

### **PR 상세**

- 비밀번호 재설정 및 유저 본인 확인 페이지 퍼블리싱
- 로그인/회원가입에 사용되었던 input이 동일하게 사용되었습니다
- 사용자 입력 정보가 틀렸을때 특정 정보가 틀렸다고 알려주지않고, 가입된 유저 정보가 없다는 노티를 띄우게 하였습니다
- 본인 확인 페이지에서 받아오는 정보는 "이름, 이메일, 핸드폰번호"를 받아오며, 추후 조건이 맞아야 비밀번호를 바꿀 수 있도록 작업할 예정입니다.
- 페이지 확인을 위해, 확인 버튼을 button태그말고, Link를 임시로 사용했습니다. 추후 button으로 변경 할 예정입니다.
<img width="683" height="982" alt="image" src="https://github.com/user-attachments/assets/379959cf-a9e1-4851-b62f-b21485fe5152" />
<img width="676" height="979" alt="image" src="https://github.com/user-attachments/assets/0900b38c-0055-4f11-805b-5de7287e5e98" />


### **이슈번호 # **
#29 