### PR TITLE
[FEAT] 33 아이디 찾기 페이지 퍼블리싱

### DIFF
--- a/src/app/(auth)/find-id-result/layout.tsx
+++ b/src/app/(auth)/find-id-result/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react"
+
+interface FrindIdResultProps {
+  children: ReactNode
+}
+
+export default function FindIdResultLayout({ children }: FrindIdResultProps) {
+  return (
+    <section className="h-full flex flex-col min-h-[calc(100vh-260px)] items-center justify-center p-14 bg-amber-100">
+      {children}
+    </section>
+  )
+}

--- a/src/app/(auth)/find-id-result/page.tsx
+++ b/src/app/(auth)/find-id-result/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function FindIdResultPage() {
+  return (
+    <div className="bg-white w-full p-10 sm:w-160 transition-all">
+      <div>
+        <strong>아이디 찾기</strong>
+      </div>
+
+      <div className="border text-center px-8 py-5 mbs-4">
+        <strong className="text-gray-400 bold">id@gmail.com</strong>
+      </div>
+
+      <Link href="/" className="block text-center w-full py-4 mbs-8 bg-gray-200 cursor-pointer">메인으로 돌아가기</Link>
+    </div>
+  )
+}

--- a/src/app/(auth)/find-id/layout.tsx
+++ b/src/app/(auth)/find-id/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react"
+
+interface FindIdLayoutProps {
+  children: ReactNode
+}
+
+export default function FindIdLayout({ children }: FindIdLayoutProps) {
+  return (
+    <section className="h-full flex flex-col min-h-[calc(100vh-260px)] items-center justify-center p-14 bg-amber-100">
+      {children}
+    </section>
+  )
+}

--- a/src/app/(auth)/find-id/page.tsx
+++ b/src/app/(auth)/find-id/page.tsx
@@ -1,0 +1,26 @@
+import InputBox from "@/app/components/InputBox";
+import Link from "next/link";
+
+export default function FIndIdPage() {
+  return (
+    <div className="bg-white w-full p-10 sm:w-160 transition-all">
+      <div>
+        <strong>아이디 찾기</strong>
+      </div>
+
+      <form action="">
+        <div className="flex flex-col gap-5 mbs-8">
+          <InputBox type="text" label="이름" name="find-id-name" placeholder="이름을 입력하세요"/>
+          <InputBox type="text" label="이메일" name="find-id-email" placeholder="이메일을 입력하세요"/>
+          <InputBox type="text" label="핸드폰 번호" name="find-id-phone" placeholder="핸드폰 번호를 입력하세요" />
+        </div>
+        <p className="mbs-2 text-center text-red-500 invisible">아이디가 존재하지 않습니다</p>
+
+        
+        {/* 실제 사용은 button으로 사용예정 연결확인을 위해 Link로 임시 연결*/}
+        <Link href={'/find-id-result'} className="block text-center w-full py-4 mbs-8 bg-gray-200 cursor-pointer">아이디 찾기</Link>
+        {/* <button type="submit" className="w-full py-4 mbs-8 bg-gray-200 cursor-pointer">아이디 찾기</button> */}
+      </form>
+    </div>
+  )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -38,9 +38,11 @@ export default function LoginPage() {
         </div>
 
         {/* 로그인 서브 */}
-        <div className="flex justify-between mbs-12">
+        <div className="grid grid-cols-1 mbs-4">
           <CheckeBox name="login-stay" label="로그인 상태유지" />
-          <Link href="/reset-password-check" className="text-gray-600">비밀번호 재설정</Link>
+          <Link href="/signup" className="text-gray-600 row-start-1 col-start-2 text-right">회원가입</Link>
+          <Link href="/find-id" className="text-gray-600 row-start-2 col-start-2 text-right">아이디 찾기</Link>
+          <Link href="/reset-password-check" className="text-gray-600 row-start-3 col-start-2 text-right">비밀번호 재설정</Link>
         </div>
 
         {/* 로그인버튼 */}


### PR DESCRIPTION
### **PR 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [X]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**

- 아이디 찾기 정보입력 페이지 퍼블리싱
- 아이디 찾기 완료 페이지 퍼블리싱

### **PR 상세**

- 아이디 찾기 정보입력 페이지버튼은 페이지 이동을위해 현재 Link로 작성되었으나, 실제 작업을 진행할때는 button으로 진행 할 예정입니다
- 로그인 페이지에 "회원가입, 아이디찾기"버튼이 추가되었습니다. 
- 해당 버튼들은 "로그인유지" 우측에 배치되었으며, flex에서 grid로 변경하였습니다
- 현재 두 페이지 전부 틀만 잡아놓은 상태이며, 디자인반영때 수정될 예정입니다

<img width="620" height="982" alt="image" src="https://github.com/user-attachments/assets/d70e6723-d422-4777-916b-3baede330b4d" />
<img width="622" height="986" alt="image" src="https://github.com/user-attachments/assets/fc309224-e77e-4128-aaa9-adafd4d7f67d" />

### **이슈번호 # **
#33 