### PR TITLE
[FEAT] 30 마이페이지 프로필 수정 페이지 퍼블리싱 

### DIFF
--- a/src/app/mypage/components/SummaryMenu.tsx
+++ b/src/app/mypage/components/SummaryMenu.tsx
@@ -26,7 +26,7 @@ export default function SummaryMenu() {
     coupons: 4,
   };
   return (
-    <div className="flex gap-8">
+    <div className="flex gap-8 w-[972px]">
       {STATS_CONFIG.map((stat) => (
         <StatCard
           key={stat.key}

--- a/src/app/mypage/consumer/profile/components/ImageUploader.tsx
+++ b/src/app/mypage/consumer/profile/components/ImageUploader.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Image from "next/image";
+import { useRef, useState } from "react";
+
+interface ImageUploaderProps {
+  label: string;
+  defaultImage?: string;
+}
+
+export default function ImageUploader({
+  label,
+  defaultImage = "/",
+}: ImageUploaderProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string>(defaultImage);
+  const handleButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setPreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 w-full">
+      <span className="text-sm font-semibold text-gray-700 ml-1">{label}</span>
+
+      <div className="flex items-center gap-4">
+        <div className="relative w-[100px] h-[100px] overflow-hidden border border-gray-200 bg-gray-50 flex items-center justify-center">
+          <Image
+            src={preview}
+            alt="프로필 미리보기"
+            fill
+            className="object-cover"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleButtonClick}
+          className="px-4 py-2 bg-white border border-gray-300 rounded text-sm font-medium text-gray-700 hover:bg-gray-50 active:bg-gray-100 transition"
+        >
+          이미지 변경
+        </button>
+        <input
+          type="file"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          accept="image/*"
+          className="hidden"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/mypage/consumer/profile/components/ProfileAction.tsx
+++ b/src/app/mypage/consumer/profile/components/ProfileAction.tsx
@@ -1,0 +1,18 @@
+export default function ProfileAction() {
+  return (
+    <div className="flex flex-col gap-3 mt-4">
+      <button
+        type="button"
+        className="text-white w-[672px] h-[50px] bg-black hover:bg-gray-800 transition"
+      >
+        비밀번호 변경
+      </button>
+      <button
+        type="button"
+        className="text-white w-24 h-10 bg-red-700 hover:bg-red-800 transition text-sm"
+      >
+        회원 탈퇴
+      </button>
+    </div>
+  );
+}

--- a/src/app/mypage/consumer/profile/components/ProfileForm.tsx
+++ b/src/app/mypage/consumer/profile/components/ProfileForm.tsx
@@ -1,0 +1,53 @@
+import { useId } from "react";
+
+interface ProfileFormProps {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  type?: string;
+  readOnly?: boolean;
+}
+
+export default function ProfileForm({
+  label,
+  name,
+  value,
+  onChange,
+  placeholder,
+  disabled = false,
+  type,
+  readOnly = false,
+}: ProfileFormProps) {
+  const id = useId();
+  const isNotEditable = disabled || readOnly;
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <label htmlFor={id} className="text-sm font-semibold text-gray-700 ml-1">
+        {label}
+      </label>
+
+      <input
+        id={id}
+        name={name}
+        type={type}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        readOnly={readOnly}
+        className={`w-[672px] h-[50px] pl-4 border border-gray-300
+           
+          ${
+            isNotEditable
+              ? "bg-gray-50  text-gray-400 cursor-not-allowed"
+              : "bg-white  text-gray-800 focus:border-gray-400 focus:ring-1 focus:ring-gray-400"
+          }
+        
+        `}
+      />
+    </div>
+  );
+}

--- a/src/app/mypage/consumer/profile/components/ProfileForm.tsx
+++ b/src/app/mypage/consumer/profile/components/ProfileForm.tsx
@@ -9,6 +9,7 @@ interface ProfileFormProps {
   disabled?: boolean;
   type?: string;
   readOnly?: boolean;
+  error?: string;
 }
 
 export default function ProfileForm({
@@ -20,9 +21,11 @@ export default function ProfileForm({
   disabled = false,
   type,
   readOnly = false,
+  error,
 }: ProfileFormProps) {
   const id = useId();
   const isNotEditable = disabled || readOnly;
+
   return (
     <div className="flex flex-col gap-2 w-full">
       <label htmlFor={id} className="text-sm font-semibold text-gray-700 ml-1">
@@ -38,16 +41,16 @@ export default function ProfileForm({
         placeholder={placeholder}
         disabled={disabled}
         readOnly={readOnly}
-        className={`w-[672px] h-[50px] pl-4 border border-gray-300
-           
+        className={`w-[672px] h-[50px] pl-4 border 
+          ${error ? "border-red-500" : "border-gray-300"} 
           ${
             isNotEditable
-              ? "bg-gray-50  text-gray-400 cursor-not-allowed"
-              : "bg-white  text-gray-800 focus:border-gray-400 focus:ring-1 focus:ring-gray-400"
+              ? "bg-gray-50 text-gray-400 cursor-not-allowed"
+              : "bg-white text-gray-800 focus:border-gray-400 focus:ring-1 focus:ring-gray-400"
           }
-        
         `}
       />
+      {error && <p className="text-xs text-red-500 ml-1">{error}</p>}
     </div>
   );
 }

--- a/src/app/mypage/consumer/profile/page.tsx
+++ b/src/app/mypage/consumer/profile/page.tsx
@@ -5,7 +5,6 @@ import ProfileForm from "./components/ProfileForm";
 import ImageUploader from "./components/ImageUploader";
 import ProfileAction from "./components/ProfileAction";
 
-// 위에서 정의한 필드 데이터 (실제로는 파일 상단에 위치)
 const PROFILE_FIELDS = [
   { label: "이메일", name: "email", type: "email", isReadOnly: true },
   { label: "이름", name: "name", type: "text", isReadOnly: true },
@@ -29,8 +28,6 @@ export default function Profile() {
 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [backupData, setBackupData] = useState(formData);
-
-  // [입력 핸들러]
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     if (errors[name]) setErrors((prev) => ({ ...prev, [name]: "" }));
@@ -43,7 +40,6 @@ export default function Profile() {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  // [수정/취소 로직]
   const handleEdit = (e: React.MouseEvent) => {
     e.preventDefault();
     setBackupData(formData);
@@ -57,15 +53,13 @@ export default function Profile() {
     setIsEditing(false);
   };
 
-  // [저장 로직]
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
     const newErrors: Record<string, string> = {};
 
     if (!formData.nickname.trim())
       newErrors.nickname = "닉네임을 입력해주세요.";
-    if (formData.phone.length > 11) newErrors.phone = "전화번호가 너무 깁니다.";
-    else if (formData.phone.length < 10 && formData.phone.length > 0)
+    if (formData.phone.length < 10 && formData.phone.length > 0)
       newErrors.phone = "전화번호가 너무 짧습니다.";
     if (!formData.address.trim()) newErrors.address = "주소를 입력해주세요.";
 

--- a/src/app/mypage/consumer/profile/page.tsx
+++ b/src/app/mypage/consumer/profile/page.tsx
@@ -1,8 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useState, SyntheticEvent } from "react";
 import ProfileForm from "./components/ProfileForm";
 import ImageUploader from "./components/ImageUploader";
+import ProfileAction from "./components/ProfileAction";
+
+// 위에서 정의한 필드 데이터 (실제로는 파일 상단에 위치)
+const PROFILE_FIELDS = [
+  { label: "이메일", name: "email", type: "email", isReadOnly: true },
+  { label: "이름", name: "name", type: "text", isReadOnly: true },
+  { label: "닉네임", name: "nickname", type: "text", isReadOnly: false },
+  { label: "휴대전화", name: "phone", type: "tel", isReadOnly: false },
+  { label: "주소", name: "address", type: "text", isReadOnly: false },
+  { label: "생일", name: "birthday", type: "date", isReadOnly: true },
+];
 
 export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
@@ -11,97 +22,109 @@ export default function Profile() {
     name: "홍길동",
     email: "user01@example.com",
     nickname: "행쇼마켓너무좋아요",
-    phone: "010-1234-5678",
+    phone: "01012345678",
     address: "서울시 강남구 테헤란로 123",
     birthday: "1990-01-01",
   });
 
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [backupData, setBackupData] = useState(formData);
+
+  // [입력 핸들러]
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+    if (errors[name]) setErrors((prev) => ({ ...prev, [name]: "" }));
+
+    if (name === "phone") {
+      const onlyNumber = value.replace(/[^0-9]/g, "").slice(0, 11);
+      setFormData((prev) => ({ ...prev, [name]: onlyNumber }));
+      return;
+    }
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  return (
-    <section className="p-8 bg-white mt-8">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-xl font-bold">프로필 수정</h1>
-        <button
-          onClick={() => setIsEditing(!isEditing)}
-          className="bg-red-400 text-white px-4 py-2"
-        >
-          {isEditing ? "저장하기" : "수정"}
-        </button>
-      </div>
+  // [수정/취소 로직]
+  const handleEdit = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setBackupData(formData);
+    setIsEditing(true);
+  };
 
-      <div className="flex flex-col gap-5">
-        <ImageUploader
-          label="프로필 이미지"
-          defaultImage={formData.profileImage}
-        />
-        <ProfileForm
-          label="이메일"
-          name="email"
-          type="email"
-          value={formData.email}
-          onChange={handleChange}
-          disabled={!isEditing}
-          readOnly={true}
-        />
-        <ProfileForm
-          label="이름"
-          name="name"
-          type="text"
-          value={formData.name}
-          onChange={handleChange}
-          disabled={!isEditing}
-          readOnly={true}
-        />
-        <ProfileForm
-          label="닉네임"
-          name="nickname"
-          type="text"
-          value={formData.nickname}
-          onChange={handleChange}
-          disabled={!isEditing}
-        />
-        <ProfileForm
-          label="휴대전화"
-          name="phone"
-          type="tel"
-          value={formData.phone}
-          onChange={handleChange}
-          disabled={!isEditing}
-        />
-        <ProfileForm
-          label="주소"
-          name="address"
-          type="text"
-          value={formData.address}
-          onChange={handleChange}
-          disabled={!isEditing}
-        />
-        <ProfileForm
-          label="생일"
-          name="birthday"
-          type="date"
-          value={formData.birthday}
-          onChange={handleChange}
-          disabled={!isEditing}
-          readOnly={true}
-        />
-        <button
-          type="button"
-          className="text-white w-[672px] h-[50px] bg-black cursor-pointer"
-        >
-          비밀번호 변경
-        </button>
-        <button
-          type="button"
-          className="text-white w-22 h-8 bg-red-700 cursor-pointer"
-        >
-          회원 탈퇴
-        </button>
-      </div>
+  const handleCancel = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setFormData(backupData);
+    setErrors({});
+    setIsEditing(false);
+  };
+
+  // [저장 로직]
+  const handleSubmit = (e: SyntheticEvent) => {
+    e.preventDefault();
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.nickname.trim())
+      newErrors.nickname = "닉네임을 입력해주세요.";
+    if (formData.phone.length > 11) newErrors.phone = "전화번호가 너무 깁니다.";
+    else if (formData.phone.length < 10 && formData.phone.length > 0)
+      newErrors.phone = "전화번호가 너무 짧습니다.";
+    if (!formData.address.trim()) newErrors.address = "주소를 입력해주세요.";
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setIsEditing(false);
+    setErrors({});
+  };
+
+  return (
+    <section className="p-8 bg-white mt-8 w-[972px] mx-auto">
+      <form onSubmit={handleSubmit} className="w-[832px]">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-xl font-bold">프로필 수정</h1>
+          <div className="flex gap-2">
+            {isEditing && (
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="bg-gray-200 text-gray-700 px-4 py-2 rounded hover:bg-gray-300 transition"
+              >
+                취소
+              </button>
+            )}
+            <button
+              type={isEditing ? "submit" : "button"}
+              onClick={!isEditing ? handleEdit : undefined}
+              className={`${isEditing ? "bg-green-500 hover:bg-green-600" : "bg-red-400 hover:bg-red-500"} text-white px-6 py-2 rounded font-medium transition`}
+            >
+              {isEditing ? "저장하기" : "수정"}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-5">
+          <ImageUploader
+            label="프로필 이미지"
+            defaultImage={formData.profileImage}
+          />
+
+          {PROFILE_FIELDS.map((field) => (
+            <ProfileForm
+              key={field.name}
+              label={field.label}
+              name={field.name}
+              type={field.type}
+              value={formData[field.name as keyof typeof formData]}
+              onChange={handleChange}
+              disabled={!isEditing}
+              readOnly={field.isReadOnly}
+              error={errors[field.name]}
+            />
+          ))}
+          <ProfileAction />
+        </div>
+      </form>
     </section>
   );
 }

--- a/src/app/mypage/consumer/profile/page.tsx
+++ b/src/app/mypage/consumer/profile/page.tsx
@@ -1,3 +1,107 @@
-export default function Orders() {
-  return <h1>프로필 관리</h1>;
+"use client";
+
+import { useState } from "react";
+import ProfileForm from "./components/ProfileForm";
+import ImageUploader from "./components/ImageUploader";
+
+export default function Profile() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [formData, setFormData] = useState({
+    profileImage: "",
+    name: "홍길동",
+    email: "user01@example.com",
+    nickname: "행쇼마켓너무좋아요",
+    phone: "010-1234-5678",
+    address: "서울시 강남구 테헤란로 123",
+    birthday: "1990-01-01",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <section className="p-8 bg-white mt-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-xl font-bold">프로필 수정</h1>
+        <button
+          onClick={() => setIsEditing(!isEditing)}
+          className="bg-red-400 text-white px-4 py-2"
+        >
+          {isEditing ? "저장하기" : "수정"}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-5">
+        <ImageUploader
+          label="프로필 이미지"
+          defaultImage={formData.profileImage}
+        />
+        <ProfileForm
+          label="이메일"
+          name="email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+          disabled={!isEditing}
+          readOnly={true}
+        />
+        <ProfileForm
+          label="이름"
+          name="name"
+          type="text"
+          value={formData.name}
+          onChange={handleChange}
+          disabled={!isEditing}
+          readOnly={true}
+        />
+        <ProfileForm
+          label="닉네임"
+          name="nickname"
+          type="text"
+          value={formData.nickname}
+          onChange={handleChange}
+          disabled={!isEditing}
+        />
+        <ProfileForm
+          label="휴대전화"
+          name="phone"
+          type="tel"
+          value={formData.phone}
+          onChange={handleChange}
+          disabled={!isEditing}
+        />
+        <ProfileForm
+          label="주소"
+          name="address"
+          type="text"
+          value={formData.address}
+          onChange={handleChange}
+          disabled={!isEditing}
+        />
+        <ProfileForm
+          label="생일"
+          name="birthday"
+          type="date"
+          value={formData.birthday}
+          onChange={handleChange}
+          disabled={!isEditing}
+          readOnly={true}
+        />
+        <button
+          type="button"
+          className="text-white w-[672px] h-[50px] bg-black cursor-pointer"
+        >
+          비밀번호 변경
+        </button>
+        <button
+          type="button"
+          className="text-white w-22 h-8 bg-red-700 cursor-pointer"
+        >
+          회원 탈퇴
+        </button>
+      </div>
+    </section>
+  );
 }

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -18,7 +18,7 @@ export default function MyPageLayout({ children }: LayoutProps) {
 
         {/* 오른쪽 메인 콘텐츠 영역 */}
         <main className="flex-1 p-4">
-          <div className="max-w-4xl mx-auto w-full">
+          <div className="mx-auto w-full">
             <SummaryMenu />
             {children}
           </div>


### PR DESCRIPTION
### **PR 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [X]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [x]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**
- 마이페이지 소비자 프로필 수정 페이지 퍼블리싱 

### **PR 상세**
- 폼은 컴포넌트로 따로 분리를 해서 map 을 통해 유지보수하기 쉽게 조립하는 식으로 작성했습니다.
- 프로필 이미지 업로더도 컴포넌트로 분리했습니다. 
- 프로필 이미지 업로더의 작동 방식은 기본 HTML input[type="file"]은 숨기고, useRef를 활용해 커스텀 UI 버튼 클릭 시 인풋이 트리거되도록 작성했습니다.
- 수정을 누르게 되면 이름,생년월일,이메일을 제외한 필드가 수정 가능한 상태로 변경되며 수정 버튼은 저장하기 버튼으로 전환됩니다. 전화번호가 10자리 미만일 경우에는 에러메시지가 출력됩니다. 
- 저장하기 버튼이 활성화 되어있는 경우 취소 버튼도 왼쪽에 추가됩니다. 수정중인 상태에서 취소를 누르면 수정하기 이전 상태로 돌아가면서 수정 가능한 상태가 비활성화됩니다. 
-  추후 유저 정보 연동/회원 탈퇴/비밀번호 변경 로직을 구현할 예정입니다. 

<img width="584" height="587" alt="image" src="https://github.com/user-attachments/assets/21f7184e-c77c-4705-9008-945c39472c2d" />
<img width="584" height="596" alt="image" src="https://github.com/user-attachments/assets/b5bc33f6-6420-4add-a54b-6cd8909fffcb" />


### **이슈번호 #30  **
