### PR TITLE
[FEAT] 제품상세 컴포넌트 분리 및 디자인 수정, 추가

### DIFF
--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/HeartButton.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/HeartButton.tsx
@@ -1,0 +1,11 @@
+import { Heart } from 'lucide-react';
+
+const HeartButton = () => {
+  return (
+    <button className="w-14 aspect-square p-2 border flex justify-center items-center">
+      <Heart />
+    </button>
+  );
+};
+
+export default HeartButton;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductInfoComponent.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductInfoComponent.tsx
@@ -1,0 +1,66 @@
+import Image from 'next/image';
+import ProductOption from './ProductOption';
+import Quantity from './Quantity';
+import TotalPrice from './TotalPrice';
+import { ShoppingCart } from 'lucide-react';
+import HeartButton from './HeartButton';
+import ProductSummary from './ProductSummary';
+
+type Product = {
+  category: string;
+  name: string;
+  originalPrice: number;
+  discountRate: number;
+  salePrice: number;
+  shipping: string[];
+  returnPolicy: string;
+  countryOfOrigin: string;
+  description: string;
+};
+type Props = {
+  product: Product;
+};
+
+const ProductInfoComponent = ({ product }: Props) => {
+  return (
+    <article className="mx-auto max-w-7xl">
+      <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 mt-6">
+        <div className="mt-10">
+          <Image src="/pen_dummy.jpg" alt={`${product.name} 제품 이미지`} width={585} height={585} className="w-full rounded-lg object-cover" />
+        </div>
+
+        <section aria-labelledby="product-info-title">
+          <h2 id="product-info-title" className="sr-only">
+            제품 소개
+          </h2>
+
+          <div>
+            <ProductSummary products={product} />
+            <div className="mt-8">
+              <ProductOption />
+            </div>
+            <div className="mt-4">
+              <Quantity />
+            </div>
+            <div className="mt-4">
+              <TotalPrice />
+            </div>
+            <div className="mt-6">
+              <div className="mt-4 flex gap-3">
+                <button
+                  type="button"
+                  className="bg-[#FF6B6B] hover:bg-[#ee6767] w-full flex items-center justify-center gap-3 transition duration-300"
+                >
+                  <ShoppingCart className="text-white w-5 h-5" /> <span className="text-white">구매하기</span>
+                </button>
+                <HeartButton />
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </article>
+  );
+};
+
+export default ProductInfoComponent;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductOption.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductOption.tsx
@@ -1,0 +1,34 @@
+import { CircleQuestionMarkIcon } from 'lucide-react';
+
+const ProductOption = () => {
+  return (
+    <>
+      <div>
+        <label htmlFor="color" className="text-[18px]">
+          색상
+        </label>
+        <select className="block border w-full py-3 mt-2" name="color" id="color">
+          <option value="black">검정</option>
+          <option value="red">빨강</option>
+          <option value="blue">파랑</option>
+        </select>
+      </div>
+
+      <div className="flex items-center mt-6">
+        <label htmlFor="size" className="text-[18px] mt-1">
+          사이즈
+        </label>
+        <button type="button" className="ml-5 cursor-pointer">
+          <CircleQuestionMarkIcon />
+        </button>
+      </div>
+      <select className="block border w-full py-3 mt-2" name="size" id="size">
+        <option value="small">small</option>
+        <option value="medium">medium</option>
+        <option value="large">large</option>
+      </select>
+    </>
+  );
+};
+
+export default ProductOption;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductSummary.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductSummary.tsx
@@ -1,0 +1,63 @@
+import { Star } from 'lucide-react';
+type ProductProps = {
+  category: string;
+  name: string;
+  originalPrice: number;
+  discountRate: number;
+  salePrice: number;
+  shipping: string[];
+  returnPolicy: string;
+  countryOfOrigin: string;
+  description: string;
+};
+
+interface Props {
+  products: ProductProps;
+}
+
+const ProductSummary = ({ products }: Props) => {
+  const formatPrice = (price: number) => `${price.toLocaleString('ko-KR')}원`;
+
+  return (
+    <>
+      <dl className="space-y-3">
+        <dt className="sr-only">제품 타입</dt>
+        <dd className="text-lg text-gray-600">{products.category}</dd>
+
+        <dt className="sr-only">제품명</dt>
+        <dd className="text-3xl font-semibold">{products.name}</dd>
+      </dl>
+      <dl className="flex">
+        <dt className="sr-only">평점</dt>
+        <dd className="flex">
+          <Star fill="#FDC700" className="text-[#FDC700]" />
+          <Star fill="#FDC700" className="text-[#FDC700]" />
+          <Star fill="#FDC700" className="text-[#FDC700]" />
+          <Star fill="#FDC700" className="text-[#FDC700]" />
+          <Star className="text-gray-200" />
+          <span className="ml-2">4.5점</span>
+        </dd>
+
+        <dt className="sr-only">리뷰 개수</dt>
+        <dd>(1,334개 리뷰)</dd>
+      </dl>
+
+      <div>
+        <dl className="flex items-center gap-2 mt-9">
+          <dt className="sr-only">정가</dt>
+          <dd className="order-2">
+            <del className="text-lg text-gray-500">{formatPrice(products.originalPrice)}</del>
+          </dd>
+
+          <dt className="sr-only">할인가</dt>
+          <dd className="order-1 text-2xl font-semibold">{formatPrice(products.salePrice)}</dd>
+        </dl>
+        <div className="discountBadge w-20.5 h-7 bg-[#ff6b6b] mt-2 pl-3 pr-3  pt-1 pb-1 flex items-center justify-center">
+          <p className="text-white">{products.discountRate}%</p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ProductSummary;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/Quantity.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/Quantity.tsx
@@ -1,0 +1,33 @@
+import { Minus, Plus } from 'lucide-react';
+
+const Quantity = () => {
+  return (
+    <div className="inline-block">
+      <label htmlFor="quantity" className="text-[18px] text-gray-700">
+        수량
+      </label>
+
+      <div className="mt-4 flex gap-1 items-center">
+        <button type="button" aria-label="한개 제거" className="border px-2.5 py-2  text-gray-600 cursor-not-allowed" disabled>
+          <Minus className="w-4" />
+        </button>
+
+        <input
+          id="quantity"
+          name="quantity"
+          type="number"
+          min={1}
+          value={1}
+          readOnly
+          className="border w-20 py-2 text-center outline-none appearance-none"
+        />
+
+        <button type="button" aria-label="한개 추가" className="border bg-white px-2.5 py-2 text-black cursor-pointer">
+          <Plus className="w-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Quantity;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/TotalPrice.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/TotalPrice.tsx
@@ -1,0 +1,10 @@
+const TotalPrice = () => {
+  return (
+    <div className="flex items-center justify-between p-4 bg-gray-100">
+      <p>총 상품 금액</p>
+      <p className="text-[#FF6B6B] text-2xl font-bold">32,000원</p>
+    </div>
+  );
+};
+
+export default TotalPrice;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/RecomandProduct.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/RecomandProduct.tsx
@@ -1,0 +1,34 @@
+import ProductsCard from '@/app/components/ProductsCard';
+import ProductsCardList from '@/app/components/ProductsCardList';
+
+type Product = {
+  id: number;
+  name: string;
+  price: number;
+  discount: number;
+  image: string;
+  category: string;
+  popularity: number;
+  createdAt: string;
+};
+
+interface RecomandProps {
+  products: Product[];
+}
+
+const RecomandProduct = ({ products }: RecomandProps) => {
+  const MAX_PAGE_SIZE = 4;
+  return (
+    <section aria-labelledby="recommend-products-title" className="mx-auto mt-16 max-w-7xl px-4">
+      <h2 id="recommend-products-title" className="mb-6 text-2xl font-semibold">
+        제품 추천
+      </h2>
+
+      <ProductsCardList>
+        <ProductsCard maxProducts={MAX_PAGE_SIZE} products={products} />
+      </ProductsCardList>
+    </section>
+  );
+};
+
+export default RecomandProduct;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/ProductInfoTable.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/ProductInfoTable.tsx
@@ -1,0 +1,49 @@
+type Product = {
+  category: string;
+  name: string;
+  originalPrice: number;
+  discountRate: number;
+  salePrice: number;
+  shipping: string[];
+  returnPolicy: string;
+  countryOfOrigin: string;
+  description: string;
+};
+type Props = {
+  product: Product;
+};
+
+const ProductInfoTable = ({ product }: Props) => {
+  return (
+    <table className="max-w-7xl m-auto w-full border-t border-b border-t-gray-200 border-b-gray-200">
+      <tbody>
+        <tr className="border-b border-b-gray-200">
+          <th className="w-32 px-4 py-3 text-left bg-gray-50 text-gray-500">재질</th>
+          <td className="px-4 py-3">천연 원목 커버, 무표백 용지</td>
+        </tr>
+
+        <tr className="border-b border-b-gray-200">
+          <th className="w-32 px-4 py-3 text-left bg-gray-50 text-gray-500">페이지</th>
+          <td className="px-4 py-3">120페이지 (60매)</td>
+        </tr>
+
+        <tr className="border-b border-b-gray-200">
+          <th className="w-32 px-4 py-3 text-left bg-gray-50 text-gray-500">용지</th>
+          <td className="px-4 py-3">80g/m² 무선 노트 용지</td>
+        </tr>
+
+        <tr className="border-b border-b-gray-200">
+          <th className="w-32 px-4 py-3 text-left bg-gray-50 text-gray-500">제본</th>
+          <td className="px-4 py-3">스프링 제본 (180도 펼침 가능)</td>
+        </tr>
+
+        <tr>
+          <th className="w-32 px-4 py-3 text-left bg-gray-50 text-gray-500">원산지</th>
+          <td className="px-4 py-3">{product.countryOfOrigin}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+export default ProductInfoTable;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/ReviewChart.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/ReviewChart.tsx
@@ -1,0 +1,106 @@
+import Image from 'next/image';
+import { Star } from 'lucide-react';
+
+const Review = () => {
+  const ratingRows = [
+    { label: '5점', percent: 70 },
+    { label: '4점', percent: 15 },
+    { label: '3점', percent: 5 },
+    { label: '2점', percent: 10 },
+    { label: '1점', percent: 0 },
+  ];
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 py-12">
+      <h2 className="text-2xl font-semibold">고객 리뷰</h2>
+
+      <div className="mt-6 grid gap-6 rounded-2xl border border-gray-200 bg-white p-6 md:grid-cols-[260px_1fr]">
+        <div className="flex flex-col items-center justify-center border-b border-gray-200 pb-6 md:border-b-0 md:border-r md:pb-0 md:pr-6">
+          <p className="text-5xl font-bold">4.5</p>
+
+          <div className="mt-3 flex">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <Star key={index} className={`h-5 w-5 ${index < 4 ? 'text-yellow-400' : 'text-gray-200'}`} fill={index < 4 ? 'currentColor' : 'none'} />
+            ))}
+          </div>
+
+          <p className="mt-2 text-sm text-gray-500">1,334개의 리뷰</p>
+        </div>
+
+        <div className="space-y-3">
+          {ratingRows.map(row => (
+            <div key={row.label} className="flex items-center gap-3">
+              <span className="w-10 text-sm text-gray-600">{row.label}</span>
+
+              <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+                <div className="h-full rounded-full bg-yellow-400" style={{ width: `${row.percent}%` }} />
+              </div>
+
+              <span className="w-10 text-right text-sm text-gray-500">{row.percent}%</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-10 space-y-6">
+        <article className="rounded-2xl border border-gray-200 p-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <strong className="font-semibold">블랙펑크</strong>
+                <span className="text-sm text-gray-400">2026.04.28</span>
+
+                <div className=" flex items-center gap-1">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <Star key={index} className="h-4 w-4 text-yellow-400" fill="currentColor" />
+                  ))}
+                  <span className="sr-only">평점 5점</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-x-2">
+              <button type="button" className="cursor-pointer rounded-full  px-3 py-1 text-sm bg-red-500 text-white">
+                삭제
+              </button>
+              <span className="cursor-pointer rounded-full bg-blue-500 px-3 py-1 text-sm text-white">수정</span>
+            </div>
+          </div>
+
+          <p className="mt-4  text-gray-700">필기감이 부드럽고 디자인도 깔끔해서 만족합니다. 포장도 꼼꼼했고, 선물용으로도 괜찮을 것 같아요.</p>
+
+          <div className="mt-5 flex gap-2">
+            <Image src="/pen_dummy.jpg" alt="리뷰 이미지 1" width={120} height={120} className="aspect-square rounded-lg object-cover" />
+            <Image src="/pen_dummy.jpg" alt="리뷰 이미지 2" width={120} height={120} className="aspect-square rounded-lg object-cover" />
+          </div>
+        </article>
+        <article className="rounded-2xl border border-gray-200 p-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <strong className="font-semibold">잠수탄 소년단</strong>
+                <span className="text-sm text-gray-400">2026.04.28</span>
+
+                <div className=" flex items-center gap-1">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <Star key={index} className="h-4 w-4 text-yellow-400" fill="currentColor" />
+                  ))}
+                  <span className="sr-only">평점 5점</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p className="mt-4  text-gray-700">필기감이 부드럽고 디자인도 깔끔해서 만족합니다. 포장도 꼼꼼했고, 선물용으로도 괜찮을 것 같아요.</p>
+
+          <div className="mt-5 flex gap-2">
+            <Image src="/pen_dummy.jpg" alt="리뷰 이미지 1" width={120} height={120} className="aspect-square rounded-lg object-cover" />
+            <Image src="/pen_dummy.jpg" alt="리뷰 이미지 2" width={120} height={120} className="aspect-square rounded-lg object-cover" />
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+};
+
+export default Review;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/TabInfoComponent.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/TabInfoComponent.tsx
@@ -1,0 +1,34 @@
+import ProductInfoTable from './ProductInfoTable';
+import Review from './ReviewChart';
+import TabProductsInfo from './TabProductsInfo';
+
+type Product = {
+  category: string;
+  name: string;
+  originalPrice: number;
+  discountRate: number;
+  salePrice: number;
+  shipping: string[];
+  returnPolicy: string;
+  countryOfOrigin: string;
+  description: string;
+};
+type Props = {
+  product: Product;
+};
+const TabInfoComponent = ({ product }: Props) => {
+  return (
+    <>
+      <TabProductsInfo product={product}>
+        <div className="mt-4">
+          <ProductInfoTable product={product} />
+        </div>
+      </TabProductsInfo>
+
+      <hr />
+      <Review />
+    </>
+  );
+};
+
+export default TabInfoComponent;

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/TabProductsInfo.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/TabProductsInfo.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from 'react';
+
+type Product = {
+  category: string;
+  name: string;
+  originalPrice: number;
+  discountRate: number;
+  salePrice: number;
+  shipping: string[];
+  returnPolicy: string;
+  countryOfOrigin: string;
+  description: string;
+};
+type Props = {
+  product: Product;
+  children: ReactNode;
+};
+
+export default function TabProductsInfo({ product, children }: Props) {
+  const DETAIL_TABS = [
+    { id: 'detail', label: '제품 상세' },
+    { id: 'store', label: '가게 정보' },
+    { id: 'review', label: '리뷰(100)' },
+  ] as const;
+
+  return (
+    <article className="mx-auto mt-16 max-w-7xl px-4">
+      <header className="border-b border-gray-200">
+        <nav aria-label="상품 상세 탭">
+          <ul className="flex gap-6">
+            {DETAIL_TABS.map(tab => (
+              <li key={tab.id}>
+                <button type="button" className="border-b-2 border-transparent text-2xl px-1 py-4 text-gray-700 hover:text-black">
+                  {tab.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </header>
+
+      <section className="py-8">
+        <h2 className="text-2xl font-semibold">제품 상세</h2>
+        <div className="contents">
+          <p className="mt-4 text-xl text-justify max-w-6xl leading-8 text-gray-700">{product.description}</p>
+        </div>
+        {children}
+      </section>
+    </article>
+  );
+}

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/TabReview.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Tab/TabReview.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TabReview = () => {
+  return <div>TabReview</div>;
+};
+
+export default TabReview;

--- a/src/app/(shop)/products/[mainCategory]/[id]/page.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/page.tsx
@@ -1,7 +1,8 @@
-import Image from 'next/image';
-import ProductsCard from '@/app/components/ProductsCard';
-import ProductsCardList from '@/app/components/ProductsCardList';
 import products from '@/data/dummyproducts.json';
+import RecomandProduct from './_components/RecomandProduct';
+import Depth from '../_component/depth';
+import ProductInfoComponent from './_components/Product/ProductInfoComponent';
+import TabInfoComponent from './_components/Tab/TabInfoComponent';
 
 const PRODUCT = {
   category: '필기구',
@@ -16,187 +17,20 @@ const PRODUCT = {
     'AI 코딩 도구를 활용하면 코드 생성 및 자동화, 개발 워크플로우와의 통합 등이 가능하며 기존 개발 환경 대비 생산성을 높일 수 있습니다. 그러나 개발자를 꿈꾸며 학습을하는 예비 개발자에게 AI 코딩 도구는 양날의 검이 될 수 있습니다. AI 코딩 도구에만 의존하는 주니어 개발자는 경쟁력을 갖출 수 없기 때문입니다. 오히려 더 깊이 있게 언어를 학습하고 좋은 질문을 할 수 있도록 문해력(Literacy)을 기르는 것이 필요합니다. 다만 AI 도구를 완전히 배제하는 것이 아닌 학습을 위한 파트너로서 활용할 것을 추천합니다.',
 };
 
-const DETAIL_TABS = [
-  { id: 'detail', label: '제품 상세' },
-  { id: 'store', label: '가게 정보' },
-  { id: 'review', label: '리뷰(100)' },
-] as const;
-
-const formatPrice = (price: number) => `${price.toLocaleString('ko-KR')}원`;
-
-function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <>
-      <dl className="flex gap-6  items-center m-0">
-        <dt className="text-gray-700 text-[18px] mr-4 mt-4 mb-4">{label}</dt>
-        <dd className=" text-sm text-gray-600 mt-4 mb-4">{children}</dd>
-      </dl>
-      <hr className="w-full border-gray-200 m-0" />
-    </>
-  );
-}
-
-function ActionButton({ children, variant = 'primary' }: { children: React.ReactNode; variant?: 'primary' | 'secondary' }) {
-  const base = 'flex-1 flex items-center justify-center gap-2 py-4 rounded-lg transition-colors';
-  const styles = variant === 'primary' ? 'bg-black text-white hover:bg-gray-800' : 'border border-gray-300 bg-white text-black hover:bg-gray-50';
-
-  return (
-    <button type="button" className={`${base} ${styles}`}>
-      {children}
-    </button>
-  );
-}
-
 export default function ProductDetailPage() {
   return (
-    <section aria-labelledby="product-detail-title" className="py-10">
+    <div aria-labelledby="product-detail-title" className="mt-5 mb-38 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <h1 id="product-detail-title" className="sr-only">
         제품 상세 페이지
       </h1>
-
-      <article className="mx-auto max-w-7xl px-4">
-        <div className="grid grid-cols-1 gap-10 lg:grid-cols-2">
-          <div className="lg:sticky lg:top-24 self-start">
-            <Image
-              src="/pen_dummy.jpg"
-              alt={`${PRODUCT.name} 제품 이미지`}
-              width={585}
-              height={585}
-              priority
-              className="w-full rounded-lg object-cover"
-            />
-          </div>
-
-          <section aria-labelledby="product-info-title">
-            <h2 id="product-info-title" className="sr-only">
-              제품 소개
-            </h2>
-
-            <div className="space-y-6">
-              <dl className="space-y-3">
-                <dt className="sr-only">제품 타입</dt>
-                <dd className="text-lg text-gray-600">{PRODUCT.category}</dd>
-
-                <dt className="sr-only">제품명</dt>
-                <dd className="text-3xl font-semibold">{PRODUCT.name}</dd>
-
-                <dt className="sr-only">정가</dt>
-                <dd>
-                  <del className="text-lg text-gray-500">{formatPrice(PRODUCT.originalPrice)}</del>
-                </dd>
-
-                <div className="flex items-center gap-3">
-                  <dt className="sr-only">할인율</dt>
-                  <dd className="text-xl font-bold text-orange-800">{PRODUCT.discountRate}%</dd>
-
-                  <dt className="sr-only">할인가</dt>
-                  <dd className="text-2xl font-semibold">{formatPrice(PRODUCT.salePrice)}</dd>
-                </div>
-              </dl>
-
-              <hr className="w-full m-0 border-gray-200" />
-
-              <InfoRow label="적립">
-                <button type="button" className="text-sm underline">
-                  등급 별 정책 확인하기 →
-                </button>
-              </InfoRow>
-
-              <InfoRow label="배송">
-                <div className="space-y-1">
-                  {PRODUCT.shipping.map(text => (
-                    <p key={text}>{text}</p>
-                  ))}
-                </div>
-              </InfoRow>
-
-              <div className="inline-block">
-                <label htmlFor="quantity" className="text-[18px] text-gray-700">
-                  개수
-                </label>
-
-                <div className="mt-4 flex items-center overflow-hidden rounded border">
-                  <button type="button" aria-label="한개 제거" className="border-r px-4 py-1 text-3xl text-gray-600 cursor-not-allowed" disabled>
-                    -
-                  </button>
-
-                  <input
-                    id="quantity"
-                    name="quantity"
-                    type="number"
-                    min={1}
-                    value={1}
-                    readOnly
-                    className="w-20 py-2.5 ml-3 text-center outline-none"
-                  />
-
-                  <button type="button" aria-label="한개 추가" className="border-l bg-white px-4 py-1 text-3xl text-black">
-                    +
-                  </button>
-                </div>
-              </div>
-
-              <div className="mt-8">
-                <button type="button" className="w-full rounded-lg bg-black py-4 text-white transition-colors hover:bg-gray-800">
-                  장바구니 담기
-                </button>
-
-                <div className="mt-4 flex gap-3">
-                  <ActionButton variant="secondary">좋아요</ActionButton>
-                  <ActionButton variant="secondary">공유하기</ActionButton>
-                </div>
-              </div>
-            </div>
-          </section>
+      <Depth mainCategory={'stationery'} productName={'제품 펜'} />
+      <main>
+        <ProductInfoComponent product={PRODUCT} />
+        <TabInfoComponent product={PRODUCT} />
+        <div className="mt-15">
+          <RecomandProduct products={products} />
         </div>
-      </article>
-
-      <article className="mx-auto mt-16 max-w-7xl px-4">
-        <header className="border-b border-gray-200">
-          <nav aria-label="상품 상세 탭">
-            <ul className="flex gap-6">
-              {DETAIL_TABS.map(tab => (
-                <li key={tab.id}>
-                  <button type="button" className="border-b-2 border-transparent text-2xl px-1 py-4 text-gray-700 transition-colors hover:text-black">
-                    {tab.label}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        </header>
-
-        <section className="py-8" aria-labelledby="detail-content-title">
-          <h2 id="detail-content-title" className="text-2xl font-semibold">
-            제품 상세
-          </h2>
-
-          <p className="mt-4 text-xl max-w-6xl text-justify break-keep leading-8 text-gray-700">{PRODUCT.description}</p>
-
-          <hr className="mt-20 border-gray-200" />
-          <InfoRow label="배송">
-            <p>{PRODUCT.shipping[0]}</p>
-          </InfoRow>
-
-          <InfoRow label="반품/교환">
-            <p>{PRODUCT.returnPolicy}</p>
-          </InfoRow>
-
-          <InfoRow label="원산지">
-            <p>{PRODUCT.countryOfOrigin}</p>
-          </InfoRow>
-        </section>
-      </article>
-
-      <section aria-labelledby="recommend-products-title" className="mx-auto mt-16 max-w-7xl px-4">
-        <h2 id="recommend-products-title" className="mb-6 text-2xl font-semibold">
-          제품 추천
-        </h2>
-
-        <ProductsCardList>
-          <ProductsCard maxProducts={4} products={products} />
-        </ProductsCardList>
-      </section>
-    </section>
+      </main>
+    </div>
   );
 }

--- a/src/app/(shop)/products/[mainCategory]/_component/depth.tsx
+++ b/src/app/(shop)/products/[mainCategory]/_component/depth.tsx
@@ -3,9 +3,10 @@ import Link from 'next/link';
 
 type DepthProps = {
   mainCategory: string;
+  productName?: string;
 };
 
-const Depth = ({ mainCategory }: DepthProps) => {
+const Depth = ({ mainCategory, productName }: DepthProps) => {
   const categoryMap: Record<string, string> = {
     stationery: '필기구',
     notebook: '노트',
@@ -21,8 +22,22 @@ const Depth = ({ mainCategory }: DepthProps) => {
         </li>
 
         <ChevronRight className="w-4 h-4" />
+        {productName ? (
+          <>
+            <li className="text-black font-medium">
+              <Link href={`/products/${mainCategory}`} aria-label={`${categoryMap[mainCategory]}로 이동하기`} className="hover:text-black">
+                {categoryMap[mainCategory] ?? mainCategory}
+              </Link>
+            </li>
 
-        <li className="text-black font-medium">{categoryMap[mainCategory] ?? mainCategory}</li>
+            <ChevronRight className="w-4 h-4" />
+            <li className="text-black font-medium">{productName}</li>
+          </>
+        ) : (
+          <>
+            <li className="text-black font-medium">{categoryMap[mainCategory] ?? mainCategory}</li>
+          </>
+        )}
       </ol>
     </nav>
   );


### PR DESCRIPTION
### **PR 유형**

- [x]  새로운 기능 추가
- [ ]  버그 수정
- x ]  CSS 등 사용자 UI 디자인 변경
- [x]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링

### **PR 체크리스트**

- 제품 상세 페이지 수정 및 추가 

### **PR 상세**

- 옵션 영역 디자인 시안과 내용에 맞춰 수정했습니다
- 디자인에 맞춰 수량 부분 디자인 변경했습니다
- 제품 요약 영역에 이미지는 하나만 넣기로 해서 임의로 디자인 수정했습니다.
- 기능별 컴포넌트 분리했습니다
- 탭 영역 리뷰 부분과 제품 설명 추가했습니다 현재 탭기능이 없어 두개다 보입니다
- 옵션에 사이즈는 sm,m,lg 로 구분하고
(사이즈는 기능 작성할때 내부 텍스트는 데이터에 있는대로 바꿀 수 있게 수정할 예정입니다. 모달을 통해 설명 할 수 있도록 버튼 추가했습니다.)

### **이슈번호 # **
#37 