### PR TITLE
[REFACTOR] 마이페이지 (소비자/ 판매자) page.tsx  서버 컴포넌트로 분리 및 페이지네이션과 찜하기 버튼 접근성 고려한 스타일링 수정

### DIFF
--- a/src/app/components/common/LikeToggleButton.tsx
+++ b/src/app/components/common/LikeToggleButton.tsx
@@ -19,7 +19,7 @@ export default function LikeToggleButton() {
     if (showToast) {
       const timer = setTimeout(() => {
         setShowToast(false);
-      }, 2000);
+      }, 1500);
 
       return () => clearTimeout(timer);
     }

--- a/src/app/components/common/LikeToggleButton.tsx
+++ b/src/app/components/common/LikeToggleButton.tsx
@@ -28,7 +28,10 @@ export default function LikeToggleButton() {
   return (
     // 버튼 누르면 찜한 상품에 추가되었다는 문구, 삭제가 되면 삭제되었다는 문구
     <>
-      <button onClick={handleLike}>
+      <button
+        onClick={handleLike}
+        aria-label={isLike ? "좋아요 해제" : "좋아요 추가"}
+      >
         {isLike ? (
           <Heart className="w-10 h-10 p-2 fill-red-500 text-red-500 transition-transform duration-200 hover:scale-130 " />
         ) : (

--- a/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function OrderItemCard({ order }: { order: OrderItem }) {
   return (
-    <div className="flex  font-semibold p-4 mb-2 border-b border-gray-300 ">
+    <div className="flex font-semibold p-4 mb-2 border-b border-gray-300 ">
       {/* 상품 이미지 및 정보 */}
       <div className="flex w-3/6 ">
         <Link

--- a/src/app/mypage/consumer/orders/components/OrderList.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderList.tsx
@@ -32,7 +32,7 @@ export default function OrderList() {
 
   return (
     <>
-      <div className="flex justify-between h-9 mb-12.5 ">
+      <div className="flex justify-between h-9 mb-12.5 pl-4">
         <TabFilter
           items={CATEGORIES}
           selectedValue={selectedCategory}

--- a/src/app/mypage/consumer/orders/components/OrderList.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderList.tsx
@@ -1,21 +1,61 @@
-import { OrderItem } from "@/app/mypage/types/orderItem";
+"use client";
+
 import OrderItemCard from "./OrderItemCard";
 import OrderItemHeader from "./OrderListHeader";
+import { usePagination } from "@/hooks/usePagination";
 
-// 마이페이지에서는 3개 정도 주문 내역 보여주고
+import { dummyOrderItems } from "@/data/dummyOrder";
+import TabFilter from "../../wishlist/components/tabFilter";
+import OrderStatusFilter from "./OrderStatusFilter";
+import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
+import { useState } from "react";
+
+// 마이페이지에서는 4개 정도 주문 내역 보여주고
 // 주문 내역 클릭 시 전부 다 보여주기
 
-export default function OrderList({ orders }: { orders: OrderItem[] }) {
+const CATEGORIES = [
+  { id: "", label: "전체" },
+  { id: "writing", label: "필기구" },
+  { id: "paper", label: "노트/메모" },
+];
+
+export default function OrderList() {
+  const [selectedStatus, setSelectedStatus] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const filteredOrders =
+    selectedStatus === ""
+      ? dummyOrderItems
+      : dummyOrderItems.filter((order) => order.itemStatus === selectedStatus);
+
+  const { currentPage, setCurrentPage, currentItems, totalPages } =
+    usePagination(filteredOrders, 5);
+
   return (
     <>
+      <div className="flex justify-between h-9 mb-12.5 ">
+        <TabFilter
+          items={CATEGORIES}
+          selectedValue={selectedCategory}
+          onValueChange={setSelectedCategory}
+        />
+        <OrderStatusFilter
+          value={selectedStatus}
+          statusChange={setSelectedStatus}
+        />
+      </div>
       <OrderItemHeader />
       <ul>
-        {orders.map((order) => (
+        {currentItems.map((order) => (
           <li key={order.id}>
             <OrderItemCard order={order} />
           </li>
         ))}
       </ul>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
     </>
   );
 }

--- a/src/app/mypage/consumer/orders/components/OrderListHeader.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderListHeader.tsx
@@ -1,7 +1,7 @@
 export default function OrderItemHeader() {
   return (
     <div className="flex font-semibold border-b p-4 mb-2">
-      <div className="w-3/6">상품 정보</div>
+      <div className="w-3/6">상품명</div>
       <div className="w-1/6 ">주문일자</div>
       <div className="w-1/6 ">결제 금액</div>
       <div className="w-1/6 ">상태</div>

--- a/src/app/mypage/consumer/orders/components/OrderStatusBadge.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderStatusBadge.tsx
@@ -1,11 +1,10 @@
 import { statusLabel } from "@/data/statusLabel";
 import { OrderItem } from "@/app/mypage/types/orderItem";
 
-
 export default function OrderStatusBadge({
-  status
+  status,
 }: {
-  status: OrderItem["status"];
+  status: OrderItem["itemStatus"];
 }) {
   const config = statusLabel[status];
 

--- a/src/app/mypage/consumer/orders/page.tsx
+++ b/src/app/mypage/consumer/orders/page.tsx
@@ -1,43 +1,10 @@
-"use client";
-
-import { dummyOrderItems } from "@/data/dummyOrder";
 import OrderList from "./components/OrderList";
-import OrderStatusFilter from "./components/OrderStatusFilter";
-import { useState } from "react";
-import TabFilter from "@/app/mypage/consumer/wishlist/components/tabFilter";
-
-const CATEGORIES = [
-  { id: "", label: "전체" },
-  { id: "writing", label: "필기구" },
-  { id: "paper", label: "노트/메모" },
-];
 
 export default function OrdersPage() {
-  const [selectedStatus, setSelectedStatus] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState("");
-
-  const filteredOrders =
-    selectedStatus === ""
-      ? dummyOrderItems
-      : dummyOrderItems.filter((order) => order.itemStatus === selectedStatus);
-
   return (
-    <div className="flex flex-col px-6 pt-6 w-full bg-white ">
+    <div className="flex flex-col px-6 pt-6 pb-11.25 w-full bg-white ">
       <h1 className="sr-only">주문 내역 조회</h1>
-      <div className="flex justify-between ">
-        <TabFilter
-          items={CATEGORIES}
-          selectedValue={selectedCategory}
-          onValueChange={setSelectedCategory}
-        />
-        <OrderStatusFilter
-          value={selectedStatus}
-          statusChange={setSelectedStatus}
-        />
-      </div>
-      <div className="mb-12.5">
-        <OrderList orders={filteredOrders} />
-      </div>
+      <OrderList />
     </div>
   );
 }

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
@@ -16,7 +16,7 @@ export default function WishListItemCard({ order }: { order: OrderItem }) {
         className="relative flex flex-col"
       >
         {order.discountRate > 0 && (
-          <div className="absolute top-0 left-0  bg-[#FF6B6B] text-white px-2 py-1 text-sm font-bold">
+          <div className="absolute top-0 left-0  bg-[#DC2626] text-white px-2 py-1 text-sm font-bold">
             {order.discountRate}%
           </div>
         )}
@@ -29,7 +29,7 @@ export default function WishListItemCard({ order }: { order: OrderItem }) {
           alt=""
         />
       </Link>
-      <div className="flex flex-col gap-2 pr-4 pt-4">
+      <div className="flex flex-col pr-4 pt-4">
         <p className="text-sm text-gray-400 ">
           {CATEGORY_TO_KOREAN[order.category]}
         </p>

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -1,14 +1,57 @@
-import { OrderItem } from "@/app/mypage/types/orderItem";
-import WishListItemCard from "./WishListItemsCard";
+"use client";
 
-export default function WishListItemsList({ items }: { items: OrderItem[] }) {
+import WishListItemCard from "./WishListItemsCard";
+import { useState } from "react";
+import TabFilter from "./tabFilter";
+import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
+import { usePagination } from "@/hooks/usePagination";
+import { dummyOrderItems } from "@/data/dummyOrder";
+
+const CATEGORIES = [
+  { id: "", label: "전체" },
+  { id: "writing", label: "필기구" },
+  { id: "paper", label: "노트/메모" },
+];
+
+export default function WishListItemsList() {
+  const [selectedValue, setSelectedValue] = useState("");
+  const { currentItems, currentPage, setCurrentPage, totalPages } =
+    usePagination(dummyOrderItems, 9);
+
   return (
-    <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6  gap-y-15 ">
-      {items.map((item) => (
-        <li key={item.id}>
-          <WishListItemCard order={item} />
-        </li>
-      ))}
-    </ul>
+    <>
+      <div className="flex justify-between ">
+        <TabFilter
+          items={CATEGORIES}
+          selectedValue={selectedValue}
+          onValueChange={setSelectedValue}
+        />
+        <label htmlFor="filter" className="sr-only">
+          필터
+        </label>
+        <select
+          name="filter"
+          id="filter"
+          className="border border-gray-400 h-9 "
+        >
+          <option value="lastProduct">등록순</option>
+          <option value="popularProduct">인기순</option>
+          <option value="highPriceProduct">가격 높은 순</option>
+          <option value="lowPriceProduct">가격 낮은 순</option>
+        </select>
+      </div>
+      <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6  gap-y-15 ">
+        {currentItems.map((item) => (
+          <li key={item.id}>
+            <WishListItemCard order={item} />
+          </li>
+        ))}
+      </ul>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
+    </>
   );
 }

--- a/src/app/mypage/consumer/wishlist/components/tabFilter.tsx
+++ b/src/app/mypage/consumer/wishlist/components/tabFilter.tsx
@@ -19,7 +19,7 @@ export default function TabFilter({
   separator = "|",
 }: TabFilterProps) {
   return (
-    <div className="flex items-center gap-3 text-md font-medium mb-12.5 h-9">
+    <div className="flex items-center pl-4 gap-3 text-md font-medium mb-12.5 h-9">
       {items.map((item, index) => (
         <div key={item.id} className="flex items-center gap-3">
           <button
@@ -32,7 +32,7 @@ export default function TabFilter({
           >
             {item.label}
           </button>
-          {/* 리스트의 마지막이 아닐 때만 구분자 표시 */}
+
           {index !== items.length - 1 && (
             <span className=" font-light">{separator}</span>
           )}

--- a/src/app/mypage/consumer/wishlist/components/tabFilter.tsx
+++ b/src/app/mypage/consumer/wishlist/components/tabFilter.tsx
@@ -19,7 +19,7 @@ export default function TabFilter({
   separator = "|",
 }: TabFilterProps) {
   return (
-    <div className="flex items-center pl-4 gap-3 text-md font-medium mb-12.5 h-9">
+    <div className="flex items-center  gap-3 text-md font-medium mb-12.5 h-9">
       {items.map((item, index) => (
         <div key={item.id} className="flex items-center gap-3">
           <button

--- a/src/app/mypage/consumer/wishlist/page.tsx
+++ b/src/app/mypage/consumer/wishlist/page.tsx
@@ -1,47 +1,14 @@
-"use client";
-import { useState } from "react";
 import WishListItemsList from "./components/WishListItemsList";
-import TabFilter from "@/app/mypage/consumer/wishlist/components/tabFilter";
 import { dummyOrderItems } from "@/data/dummyOrder";
 
-const CATEGORIES = [
-  { id: "", label: "전체" },
-  { id: "writing", label: "필기구" },
-  { id: "paper", label: "노트/메모" },
-];
-
-const MAX_COUNT = 9;
 const HAS_WISH_PRODUCTS = dummyOrderItems.length > 0;
 
 export default function WishlistPage() {
-  const [selectedValue, setSelectedValue] = useState("");
   return (
     <div className="w-full bg-white pt-6 px-6 pb-11.25 ">
       <h1 className="text-2xl font-bold mb-8 sr-only">찜한 상품</h1>
-      <div className="flex justify-between ">
-        <TabFilter
-          items={CATEGORIES}
-          selectedValue={selectedValue}
-          onValueChange={setSelectedValue}
-        />
-        <label htmlFor="filter" className="sr-only">
-          필터
-        </label>
-        <select
-          name="filter"
-          id="filter"
-          className="border border-gray-400 h-9 "
-        >
-          <option value="lastProduct">등록순</option>
-          <option value="popularProduct">인기순</option>
-          <option value="highPriceProduct">가격 높은 순</option>
-          <option value="lowPriceProduct">가격 낮은 순</option>
-        </select>
-      </div>
       {HAS_WISH_PRODUCTS ? (
-        <div>
-          <WishListItemsList items={dummyOrderItems.slice(0, MAX_COUNT)} />
-        </div>
+        <WishListItemsList />
       ) : (
         <div className="text-red-500 text-center pt-3">
           <p>찜한 상품이 없습니다.</p>{" "}

--- a/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
@@ -6,6 +6,7 @@ import Pagination from "./Pagination";
 import TabFilter from "@/app/mypage/consumer/wishlist/components/tabFilter";
 import DeliveryProductHeader from "./DeliveryProductHeader";
 import useDeliveryOrders from "@/hooks/useDeliveryOrders";
+import { useEffect } from "react";
 
 const myProductIds = [
   "prod-1",
@@ -37,7 +38,11 @@ export default function DeliveryProductList() {
 
   // 2. 페이지네이션 (UI 레이어)
   const { currentPage, setCurrentPage, totalPages, currentItems } =
-    usePagination(sortedOrders, 5);
+    usePagination(sortedOrders, 4);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [sortType, setCurrentPage]);
 
   return (
     <div className="flex flex-col">

--- a/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
@@ -36,7 +36,7 @@ export default function DeliveryProductList() {
   const { sortType, handleTabChange, sortedOrders } =
     useDeliveryOrders(myProductIds);
 
-  // 2. 페이지네이션 (UI 레이어)
+  // 2. 페이지네이션
   const { currentPage, setCurrentPage, totalPages, currentItems } =
     usePagination(sortedOrders, 4);
 
@@ -47,17 +47,13 @@ export default function DeliveryProductList() {
   return (
     <div className="flex flex-col">
       <div className="flex  flex-col ">
-        {/* TAB = 정렬 스위치 */}
         <TabFilter
           items={CATEGORIES}
           selectedValue={sortType}
           onValueChange={(id) => handleTabChange(id, CATEGORIES)}
         />
         <div>
-          {/* HEADER */}
           <DeliveryProductHeader />
-
-          {/* LIST */}
           <ul>
             {currentItems.map((item) => (
               <li key={item.id}>
@@ -67,8 +63,6 @@ export default function DeliveryProductList() {
           </ul>
         </div>
       </div>
-
-      {/* PAGINATION */}
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}

--- a/src/app/mypage/seller/delivery/components/Pagination.tsx
+++ b/src/app/mypage/seller/delivery/components/Pagination.tsx
@@ -33,7 +33,7 @@ export default function Pagination({
           onClick={() => onPageChange(i + 1)}
           disabled={currentPage === i + 1}
           aria-disabled={currentPage === i + 1}
-          className={` px-2 py-1${currentPage === i + 1 ? "text-red-500 font-bold" : ""}
+          className={` px-2 py-1 ${currentPage === i + 1 ? "text-red-500 font-bold" : ""}
       
      
     `}

--- a/src/app/mypage/seller/delivery/components/Pagination.tsx
+++ b/src/app/mypage/seller/delivery/components/Pagination.tsx
@@ -1,3 +1,10 @@
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
+
 interface Props {
   currentPage: number;
   totalPages: number;
@@ -14,29 +21,24 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(1)}
         aria-disabled={currentPage === 1}
-        className={` aria-disabled:cursor-not-allowed`}
+        className={`aria-disabled:cursor-not-allowed`}
       >
-        {"<<"}
+        <ChevronsLeft />
       </button>
 
       <button
         onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
         aria-disabled={currentPage === 1}
-        className={` aria-disabled:cursor-not-allowed`}
+        className={`aria-disabled:cursor-not-allowed`}
       >
-        {"<"}
+        <ChevronLeft />
       </button>
 
       {Array.from({ length: totalPages }, (_, i) => (
         <button
           key={i}
           onClick={() => onPageChange(i + 1)}
-          disabled={currentPage === i + 1}
-          aria-disabled={currentPage === i + 1}
-          className={` px-2 py-1 ${currentPage === i + 1 ? "text-red-500 font-bold" : ""}
-      
-     
-    `}
+          className={` px-2 py-1 ${currentPage === i + 1 ? "text-red-500 font-bold" : ""}`}
         >
           {i + 1}
         </button>
@@ -47,15 +49,15 @@ export default function Pagination({
         aria-disabled={currentPage === totalPages}
         className={` aria-disabled:cursor-not-allowed`}
       >
-        {">"}
+        <ChevronRight />
       </button>
 
       <button
         onClick={() => onPageChange(totalPages)}
         aria-disabled={currentPage === totalPages}
-        className={` aria-disabled:cursor-not-allowed`}
+        className={`aria-disabled:cursor-not-allowed`}
       >
-        {">>"}
+        <ChevronsRight />
       </button>
     </div>
   );

--- a/src/app/mypage/seller/delivery/components/Pagination.tsx
+++ b/src/app/mypage/seller/delivery/components/Pagination.tsx
@@ -21,17 +21,19 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(1)}
         aria-disabled={currentPage === 1}
-        className={`aria-disabled:cursor-not-allowed`}
+        className={`aria-disabled:cursor-not-allowed `}
+        aria-label="맨 처음 페이지"
       >
-        <ChevronsLeft />
+        <ChevronsLeft aria-hidden="true" />
       </button>
 
       <button
         onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
         aria-disabled={currentPage === 1}
-        className={`aria-disabled:cursor-not-allowed`}
+        className={`aria-disabled:cursor-not-allowed `}
+        aria-label="이전 페이지"
       >
-        <ChevronLeft />
+        <ChevronLeft aria-hidden="true" />
       </button>
 
       {Array.from({ length: totalPages }, (_, i) => (
@@ -47,17 +49,19 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
         aria-disabled={currentPage === totalPages}
-        className={` aria-disabled:cursor-not-allowed`}
+        className={` aria-disabled:cursor-not-allowed `}
+        aria-label="다음 페이지"
       >
-        <ChevronRight />
+        <ChevronRight aria-hidden="true" />
       </button>
 
       <button
         onClick={() => onPageChange(totalPages)}
         aria-disabled={currentPage === totalPages}
-        className={`aria-disabled:cursor-not-allowed`}
+        className={`aria-disabled:cursor-not-allowed `}
+        aria-label="맨 마지막 페이지"
       >
-        <ChevronsRight />
+        <ChevronsRight aria-hidden="true" />
       </button>
     </div>
   );

--- a/src/hooks/useDeliveryOrders.ts
+++ b/src/hooks/useDeliveryOrders.ts
@@ -1,26 +1,30 @@
 import { dummyOrderItems } from "@/data/dummyOrder";
 import { useMemo, useState } from "react";
 
+// 탭에서 선택되는 정렬 기준을 정의한 타입 지정
 type SortType = "All" | "latest" | "oldest" | "highPrice" | "lowPrice";
+
+// 배송 관리에 포함할 주문 상태 타입 지정
 type SalesStatus = "PAID" | "SHIPPED" | "DELIVERED";
 
-type Order = {
-  unitPrice: number;
-  discountRate: number;
-  orderTime: number;
-};
-
+// 탭 UI 하나를 표현하는 데이터 구조
 interface Category {
   id: string;
   label: string;
   sort: SortType;
 }
+
 const ALLOWED_STATUS: SalesStatus[] = ["PAID", "SHIPPED", "DELIVERED"] as const;
 
 export default function useDeliveryOrders(myProductIds: string[]) {
   const [sortType, setSortType] = useState<SortType>("latest");
 
+  // 1. 데이터 추출
+  // 조건에 맞는 데이터 배열 새로 만들기
   const myOrders = useMemo(() => {
+    // myProductIds가 변경될 때만 필터링 + 변환 다시 실행
+    // 더미 아이템에서 나의 상품 아이디와 일치하고, ["PAID", "SHIPPED", "DELIVERED"] 상태를 포함한 데이터들만 1차 필터링
+    // 필터링한 데이터를 map을 사용하여 새로운 배열 반환 (주문 날짜는 숫자로 변환)
     return dummyOrderItems
       .filter(
         (item) =>
@@ -33,18 +37,21 @@ export default function useDeliveryOrders(myProductIds: string[]) {
       }));
   }, [myProductIds]);
 
-  // 2. 탭 = 정렬 변경
+  // 2. 데이터 가공
+  // 해당 탭에 따라서 데이터 정렬해주는 핸들러 함수 만들기
   const handleTabChange = (id: string, categories: readonly Category[]) => {
+    // 카테고리 아이디와 일치하는 탭 아이디 찾기
     const selectedTab = categories.find((tab) => tab.id === id);
 
+    // 만약 선택된 탭이 일치한다면, 선택한 탭에 맞는 sort 값을 찾아서 내부 상태(sortType)를 변경
     if (selectedTab) {
       setSortType(selectedTab.sort);
     }
   };
-  const getFinalPrice = (order: Order) =>
-    order.unitPrice * (1 - order.discountRate / 100);
 
-  // 3. 정렬만 존재 (필터 제거)
+  //3. 데이터 정렬
+  // 탭 종류에 따라 해당 데이터 키값을 반환해주는 함수
+  // sortType에 따라 myOrders 정렬해서 반환
   const sortedOrders = useMemo(() => {
     if (sortType === "All") {
       return myOrders;
@@ -58,9 +65,15 @@ export default function useDeliveryOrders(myProductIds: string[]) {
           return a.orderTime - b.orderTime;
 
         case "highPrice":
-          return getFinalPrice(b) - getFinalPrice(a);
+          return (
+            b.unitPrice * (1 - b.discountRate / 100) -
+            a.unitPrice * (1 - a.discountRate / 100)
+          );
         case "lowPrice":
-          return getFinalPrice(a) - getFinalPrice(b);
+          return (
+            a.unitPrice * (1 - a.discountRate / 100) -
+            b.unitPrice * (1 - b.discountRate / 100)
+          );
 
         default:
           return 0;


### PR DESCRIPTION
### **PR 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [x]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [x]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**

- mypage/consumer  와 mypage/seller page.tsx 서버 컴포넌트로 구분
- likeToggleButton과 Pagnation  컴포넌트 접근성 고려

### **PR 상세**

-  mypage/consumer  와 mypage/seller page.tsx가 자식 컴포넌트에게 상태를 전달해야줘야 해서 'use client'로 만들어서 코드 작업을 했습니다. 이 부분을 상태를 따로 커스텀 훅을 사용함에 따라 자식 컴포넌트에서 커스텀 훅을 사용하여, 클라이언트 컴포넌트로 만들고 마이페이지 소비자와 판매자 page.tsx는 서버 컴포넌트로 분리하는 작업을 했습니다. 
- 찜하기 버튼과 페이지네이션에 UI  표시용 아이콘들을 aria-hidden: 'true'를 주고, 페이지네이션의 이전과 다음을 나타내는 아이콘에 aria-label 속성 추가를 해주었습니다.
- 페이지네이션이 필요한 상품 목록과 찜한 상품 페이지에도 커스텀 훅 usePagination과 UI 용 pagnation을 사용하여 두 페이지에도 페이지네이션을 적용했습니다. 전역적으로 사용할 수 있을 것 같습니다. 
- 접근성을 고려하여 찜한 상품 페이지의 상품 이미지 위에 표시되는 할인율 배경색 또한 조정했습니다.


[참고 이미지]

주문 내역
<img width="2720" height="2328" alt="image" src="https://github.com/user-attachments/assets/c516504a-46bb-4740-a36d-adfa401bc1b0" />
<br/><br/>
찜한 상품
<img width="2720" height="3090" alt="image" src="https://github.com/user-attachments/assets/3a9154c4-8d5d-4fb9-b13a-e58583955b03" />


### **이슈번호 # 52**
