### PR TITLE
Feat 56 마이페이지 나의 찜한 상품 좋아요 버튼 로직 추가

### DIFF
--- a/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
@@ -19,7 +19,9 @@ export default function OrderItemCard({ order }: { order: OrderItem }) {
             src={order.image}
             alt=""
           />
-          <h2 className="self-center hover:text-red-500">{order.name}</h2>
+          <h2 className="self-center hover:text-red-500 hover:font-extrabold">
+            {order.name}
+          </h2>
         </Link>
       </div>
       {/* 주문 일자 */}

--- a/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
@@ -19,7 +19,7 @@ export default function OrderItemCard({ order }: { order: OrderItem }) {
             src={order.image}
             alt=""
           />
-          <h2 className="self-center">{order.name}</h2>
+          <h2 className="self-center hover:text-red-500">{order.name}</h2>
         </Link>
       </div>
       {/* 주문 일자 */}

--- a/src/app/mypage/consumer/wishlist/components/LikeToggleButton.tsx
+++ b/src/app/mypage/consumer/wishlist/components/LikeToggleButton.tsx
@@ -1,29 +1,42 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useRef, useState } from "react";
 import { Heart } from "lucide-react";
 
-export default function LikeToggleButton() {
+interface Props {
+  id: string;
+  onRemove: (id: string) => void;
+}
+
+export default function LikeToggleButton({ id, onRemove }: Props) {
   const [isLike, setIsLike] = useState(true);
   const [showToast, setShowToast] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   const handleLike = () => {
     const nextLikeStatus = !isLike;
+
     setIsLike(nextLikeStatus);
-
-    //추가/해체 모두 다 토스트 보여줘야함
     setShowToast(true);
-  };
 
-  useEffect(() => {
-    if (showToast) {
-      const timer = setTimeout(() => {
-        setShowToast(false);
-      }, 1500);
+    // 추가, 해체를 연속으로 하게 되는 경우, 기존에는 useEffect를 사용하여,
+    // 토스트 메시지가 기존의 타이머 값에 의해 빠르게 사라짐
+    // 따라서 이를 해결하기 위해 useRef를 사용하여, 타이머 값을 기억하고
+    // 클릭할 때마다 기존 타이머를 clearTimeout으로 제거한 뒤
+    // 새로운 타이머를 설정하여 항상 마지막 액션 기준으로 1.5초 동안 유지되도록 처리
+    // 새로운 타이머 실행되었을 시, 좋아요 해제상태라면 해당 아이템 카드 제거하기
 
-      return () => clearTimeout(timer);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
     }
-  }, [showToast]);
+
+    timerRef.current = setTimeout(() => {
+      setShowToast(false);
+      if (nextLikeStatus === false) {
+        onRemove(id);
+      }
+    }, 1500);
+  };
 
   return (
     // 버튼 누르면 찜한 상품에 추가되었다는 문구, 삭제가 되면 삭제되었다는 문구

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
@@ -1,4 +1,4 @@
-import LikeToggleButton from "@/app/components/common/LikeToggleButton";
+import LikeToggleButton from "@/app/mypage/consumer/wishlist/components/LikeToggleButton";
 import Link from "next/link";
 import Image from "next/image";
 import { OrderItem } from "@/app/mypage/types/orderItem";
@@ -8,12 +8,17 @@ const CATEGORY_TO_KOREAN: { writing: string; paper: string } = {
   paper: "노트/메모",
 };
 
-export default function WishListItemCard({ order }: { order: OrderItem }) {
+interface Props {
+  order: OrderItem;
+  onRemove: (id: string) => void;
+}
+
+export default function WishListItemCard({ order, onRemove }: Props) {
   return (
     <div key={order.id} className="flex flex-col">
       <Link
         href={`/products/pen/${order.id}`}
-        className="relative flex flex-col"
+        className="relative flex flex-col transition-transform duration-400 hover:scale-105"
       >
         {order.discountRate > 0 && (
           <div className="absolute top-0 left-0  bg-[#DC2626] text-white px-2 py-1 text-sm font-bold">
@@ -24,7 +29,7 @@ export default function WishListItemCard({ order }: { order: OrderItem }) {
         <Image
           width={282}
           height={282}
-          className="object-fill"
+          className="object-fill "
           src={order.image}
           alt=""
         />
@@ -35,7 +40,7 @@ export default function WishListItemCard({ order }: { order: OrderItem }) {
         </p>
         <div className="flex justify-between">
           <p className="font-bold self-center">{order.name}</p>
-          <LikeToggleButton />
+          <LikeToggleButton id={order.id} onRemove={onRemove} />
         </div>
 
         <div className="flex gap-2">

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -15,8 +15,15 @@ const CATEGORIES = [
 
 export default function WishListItemsList() {
   const [selectedValue, setSelectedValue] = useState("");
+  const [filterValue, setFilterValue] = useState([...dummyOrderItems]);
+
   const { currentItems, currentPage, setCurrentPage, totalPages } =
-    usePagination(dummyOrderItems, 9);
+    usePagination(filterValue, 9);
+
+  const onRemove = (id: string) => {
+    const newFilterValue = filterValue.filter((item) => item.id !== id);
+    setFilterValue(newFilterValue);
+  };
 
   return (
     <>
@@ -43,7 +50,7 @@ export default function WishListItemsList() {
       <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6  gap-y-15 ">
         {currentItems.map((item) => (
           <li key={item.id}>
-            <WishListItemCard order={item} />
+            <WishListItemCard order={item} onRemove={onRemove} />
           </li>
         ))}
       </ul>

--- a/src/app/mypage/not-found.tsx
+++ b/src/app/mypage/not-found.tsx
@@ -1,9 +1,0 @@
-export default function notFound() {
-  return (
-    <section className="w-full min-h-screen bg-[#FFF8F3]">
-      <div className="bg-white">
-        <p>페이지를 찾을 수 없습니다.</p>
-      </div>
-    </section>
-  );
-}

--- a/src/app/mypage/not-found.tsx
+++ b/src/app/mypage/not-found.tsx
@@ -1,0 +1,9 @@
+export default function notFound() {
+  return (
+    <section className="w-full min-h-screen bg-[#FFF8F3]">
+      <div className="bg-white">
+        <p>페이지를 찾을 수 없습니다.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,9 @@
+export default function notFound() {
+  return (
+    <section className="w-full min-h-screen bg-[#FFF8F3] flex flex-col ">
+      <div className="w-1/2 h-1/2 aspect-square m-auto  bg-white flex flex-col justify-center items-center ">
+        <p className="text-5xl">페이지를 찾을 수 없습니다.</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### **PR 유형**

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [x]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**

- 좋아요 버튼 해체 시 해당 아이템 카드 삭제
- 좋아요 버튼 연속 클릭 시 마지막에 누른 값의 타이머 실행

### **PR 상세**
- 좋아요 버튼을 추가와 해체를 반복적으로 누를 수 있는 상황에 대비하여, 마지막에 누른 상태(추가 또는 해체)에 따라서 해당 상태에 타이머를 실행해주는 로직을 추가했습니다.
- 이 과정에서 useEffect 대신 useRef와 setTimeout을 사용하였습니다. 토스트메시지는 상태 감지가 아니라 클릭 이벤트 했을 때 시간을 제어하는 것이기때문에 셋 타임아웃만을 사용했습니다.
- 연속 클릭으로 발생하는 타이머 충돌을 방지하고, 리렌더 없이 이전 타이머를 관리하기 위해 useRef를 사용했습니다.
- 코드 안에 주석을 추가하였으니, 참고하시면 좋을 것 같습니다!
- 주문 상품의 상품명과 찜한 상품의 이미지에 마우스를 올렸을 때 호버 스타일링을 추가했습니다.
- 좋아요 버튼 파일 위치를 myPage/wishlist/components 로 옮겼습니다.

### **이슈번호 # 56 **
