### PR TITLE
[FEAT] 50 마이페이지 쿠폰관리 페이지 퍼블리싱 

### DIFF
--- a/src/app/mypage/consumer/coupons/components/CouponItem.tsx
+++ b/src/app/mypage/consumer/coupons/components/CouponItem.tsx
@@ -1,0 +1,50 @@
+import { UserCouponCombined } from "@/app/mypage/types/coupon";
+
+interface CouponItemProps {
+  userCoupon: UserCouponCombined;
+}
+
+export default function CouponItem({ userCoupon }: CouponItemProps) {
+  const { coupon_details, is_used } = userCoupon;
+
+  /**
+   * 할인 표시 로직:
+   * discount_rate가 100 이하이면 % 할인
+   * 100보다 크면 원 할인
+   */
+  const isPercentage = coupon_details.discount_rate <= 100;
+  const discountDisplay = isPercentage
+    ? `${coupon_details.discount_rate}%`
+    : `${coupon_details.discount_rate.toLocaleString()}원`;
+
+  return (
+    <div
+      className={`w-full flex items-center justify-between p-6 border border-gray-200 ${
+        is_used ? "bg-gray-50" : "bg-white"
+      }`}
+    >
+      <div className="flex flex-col gap-1">
+        <span className="text-lg font-medium">{coupon_details.name}</span>
+        <span className="text-2xl font-bold text-[#FF6B6B]">
+          {discountDisplay} 할인
+        </span>
+
+        <p className="text-sm text-[#4A5565]">
+          유효기간 : {new Date(coupon_details.expired_at).toLocaleDateString()}
+        </p>
+      </div>
+
+      {/* is_used 상태에 따라 버튼의 텍스트와 스타일을 동적으로 변경 */}
+      <button
+        disabled={is_used}
+        className={`px-4 py-1.5 rounded-xl text-xs transition-colors ${
+          is_used
+            ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+            : "bg-black text-white hover:bg-gray-800"
+        }`}
+      >
+        {is_used ? "사용완료" : "사용가능"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/mypage/consumer/coupons/components/CouponList.tsx
+++ b/src/app/mypage/consumer/coupons/components/CouponList.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { UserCouponCombined } from "@/app/mypage/types/coupon";
+import CouponItem from "./CouponItem";
+import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
+import { usePagination } from "@/hooks/usePagination";
+
+interface Props {
+  initialCoupons: UserCouponCombined[];
+}
+
+export default function CouponList({ initialCoupons }: Props) {
+  const { currentPage, setCurrentPage, currentItems, totalPages } =
+    usePagination(initialCoupons, 5);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {currentItems.length > 0 ? (
+        <>
+          <div className="flex flex-col gap-4">
+            {currentItems.map((userCoupon) => (
+              <CouponItem key={userCoupon.id} userCoupon={userCoupon} />
+            ))}
+          </div>
+
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </>
+      ) : (
+        <div className="py-20 text-center text-gray-500">
+          사용 가능한 쿠폰이 없습니다.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/mypage/consumer/coupons/page.tsx
+++ b/src/app/mypage/consumer/coupons/page.tsx
@@ -1,3 +1,18 @@
-export default function Coupons() {
-  return <h1>쿠폰 관리</h1>;
+import { dummyUserCoupons } from "@/data/dummyCouponLists";
+import CouponItem from "./components/CouponItem";
+
+export default function Coupon() {
+  return (
+    <div className="flex flex-col gap-4 w-full py-12 px-18 bg-white">
+      {dummyUserCoupons.length > 0 ? (
+        dummyUserCoupons.map((userCoupon) => (
+          <CouponItem key={userCoupon.id} userCoupon={userCoupon} />
+        ))
+      ) : (
+        <p className="text-gray-500 text-center py-20">
+          사용 가능한 쿠폰이 없습니다.
+        </p>
+      )}
+    </div>
+  );
 }

--- a/src/app/mypage/consumer/coupons/page.tsx
+++ b/src/app/mypage/consumer/coupons/page.tsx
@@ -1,18 +1,14 @@
 import { dummyUserCoupons } from "@/data/dummyCouponLists";
-import CouponItem from "./components/CouponItem";
+import CouponList from "./components/CouponList";
 
-export default function Coupon() {
+export default function CouponPage() {
+  // 현재는 더미 데이터를 사용합니다.
+  const coupons = dummyUserCoupons;
+
   return (
-    <div className="flex flex-col gap-4 w-full py-12 px-18 bg-white">
-      {dummyUserCoupons.length > 0 ? (
-        dummyUserCoupons.map((userCoupon) => (
-          <CouponItem key={userCoupon.id} userCoupon={userCoupon} />
-        ))
-      ) : (
-        <p className="text-gray-500 text-center py-20">
-          사용 가능한 쿠폰이 없습니다.
-        </p>
-      )}
+    <div className="flex flex-col w-full py-12 px-18 bg-white">
+      <h1 className="text-2xl font-bold mb-8">내 쿠폰함</h1>
+      <CouponList initialCoupons={coupons} />
     </div>
   );
 }

--- a/src/app/mypage/types/coupon.ts
+++ b/src/app/mypage/types/coupon.ts
@@ -1,0 +1,25 @@
+// 원본 쿠폰 정보 (coupons 테이블)
+export interface Coupon {
+  id: string;
+  name: string;
+  discount_rate: number;
+  start_at: string;
+  expired_at: string;
+}
+
+// 사용자가 보유한 쿠폰 정보 (user_coupons 테이블 + 원본 쿠폰 정보)
+export interface UserCouponCombined {
+  id: string; // user_coupons의 고유 ID
+  user_id: string;
+  coupon_id: string; // 연결된 원본 쿠폰 ID
+  is_used: boolean; // 사용 여부 (user_coupons 필드)
+  used_at: string | null;
+  created_at: string; // 발급 일시
+
+  // JOIN을 통해 가져오는 원본 쿠폰 상세 정보
+  coupon_details: Coupon;
+}
+
+export interface CouponItemProps {
+  userCoupon: UserCouponCombined;
+}

--- a/src/data/dummyCouponLists.ts
+++ b/src/data/dummyCouponLists.ts
@@ -1,0 +1,154 @@
+import { UserCouponCombined } from "@/app/mypage/types/coupon";
+
+export const dummyUserCoupons: UserCouponCombined[] = [
+  {
+    id: "uc-1",
+    user_id: "user-kim",
+    coupon_id: "cp-1",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-01T10:00:00Z",
+    coupon_details: {
+      id: "cp-1",
+      name: "신규 가입 축하 쿠폰",
+      discount_rate: 10, // 10%
+      start_at: "2026-05-01T00:00:00Z",
+      expired_at: "2026-12-31T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-2",
+    user_id: "user-kim",
+    coupon_id: "cp-2",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-02T11:00:00Z",
+    coupon_details: {
+      id: "cp-2",
+      name: "첫 구매 감사 쿠폰",
+      discount_rate: 5000, // 5,000원
+      start_at: "2026-05-02T00:00:00Z",
+      expired_at: "2026-06-30T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-3",
+    user_id: "user-kim",
+    coupon_id: "cp-3",
+    is_used: true,
+    used_at: "2026-05-03T15:00:00Z",
+    created_at: "2026-05-01T10:00:00Z",
+    coupon_details: {
+      id: "cp-3",
+      name: "가정의 달 깜짝 쿠폰",
+      discount_rate: 15, // 15%
+      start_at: "2026-05-01T00:00:00Z",
+      expired_at: "2026-05-31T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-4",
+    user_id: "user-kim",
+    coupon_id: "cp-4",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-04T09:00:00Z",
+    coupon_details: {
+      id: "cp-4",
+      name: "스승의 날 감사 쿠폰",
+      discount_rate: 3000, // 3,000원
+      start_at: "2026-05-15T00:00:00Z",
+      expired_at: "2026-05-20T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-5",
+    user_id: "user-kim",
+    coupon_id: "cp-5",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-04T10:30:00Z",
+    coupon_details: {
+      id: "cp-5",
+      name: "장바구니 구제 쿠폰",
+      discount_rate: 20, // 20%
+      start_at: "2026-05-01T00:00:00Z",
+      expired_at: "2026-05-10T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-6",
+    user_id: "user-kim",
+    coupon_id: "cp-6",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-04T12:00:00Z",
+    coupon_details: {
+      id: "cp-6",
+      name: "주말 브런치 특별 쿠폰",
+      discount_rate: 2000, // 2,000원
+      start_at: "2026-05-09T00:00:00Z",
+      expired_at: "2026-05-11T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-7",
+    user_id: "user-kim",
+    coupon_id: "cp-7",
+    is_used: true,
+    used_at: "2026-04-30T18:00:00Z",
+    created_at: "2026-04-20T10:00:00Z",
+    coupon_details: {
+      id: "cp-7",
+      name: "컴백 환영 웰컴백 쿠폰",
+      discount_rate: 30, // 30%
+      start_at: "2026-04-20T00:00:00Z",
+      expired_at: "2026-05-20T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-8",
+    user_id: "user-kim",
+    coupon_id: "cp-8",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-04T14:00:00Z",
+    coupon_details: {
+      id: "cp-8",
+      name: "문구류 카테고리 할인",
+      discount_rate: 1000, // 1,000원
+      start_at: "2026-05-01T00:00:00Z",
+      expired_at: "2026-05-31T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-9",
+    user_id: "user-kim",
+    coupon_id: "cp-9",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-04T15:00:00Z",
+    coupon_details: {
+      id: "cp-9",
+      name: "생일 축하해용 쿠폰",
+      discount_rate: 50, // 50%
+      start_at: "2026-05-01T00:00:00Z",
+      expired_at: "2026-05-31T23:59:59Z",
+    },
+  },
+  {
+    id: "uc-10",
+    user_id: "user-kim",
+    coupon_id: "cp-10",
+    is_used: false,
+    used_at: null,
+    created_at: "2026-05-04T16:00:00Z",
+    coupon_details: {
+      id: "cp-10",
+      name: "앱 설치 감사 쿠폰",
+      discount_rate: 10000, // 10,000원
+      start_at: "2026-05-01T00:00:00Z",
+      expired_at: "2026-12-31T23:59:59Z",
+    },
+  },
+];


### PR DESCRIPTION
### **PR 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [X]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [X]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**
- 마이페이지 쿠폰 관리 퍼블리싱 

### **PR 상세**
- 페이지네이션은 우선 마이페이지에서 작업하신 예지님 컴포넌트를 사용했습니다.- 추후 사용할 페이지네이션 컴포넌트가 확정되면 교체할 예정입니다. 
- page.tsx 에서 쿠폰 컴포넌트를 조립하고 렌더링을 진행했다가 추후 서버 사이드 렌더링을 진행하기 위해 쿠폰 아이템 컴포넌트를 쿠폰 리스트 클라이언트 컴포넌트로 분리해서 작성했습니다. 
- 임시로 쿠폰 더미 데이터와 타입을 파일로 분리해 작성했습니다. 
- 쿠폰 데이터가 존재하지 않을 경우의 예외 UI 도 작성했습니다. 
- 쿠폰의 discount_rate 가 100 이하일 경우에는 퍼센트 할인, 그 이상일 경우에는 금액 할인으로 조건부 렌더링이 되도록 작성했습니다. 
- 사용자가 개별로 가지는 쿠폰 정보와 원본 쿠폰 정보 테이블을 결합하여 사용할 수 있도록 했습니다. 
- 추후 요약 메뉴 바의 쿠폰 갯수와 쿠폰 관리에서 나타나는 쿠폰 갯수를 데이터와 연동해 일치하도록 조정할 예정입니다. 
<img width="690" height="634" alt="image" src="https://github.com/user-attachments/assets/1771c42c-d713-4340-ab49-66806bc9cb0d" />


### **이슈번호 #50  **
