### PR TITLE
[FEAT] 102 마이페이지 찜한 상품 데이터 페치 및 탭 정렬 로직 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "xgiayrmzgokjzwwzivzi.supabase.co",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/lib/Categories.ts
+++ b/src/app/lib/Categories.ts
@@ -10,3 +10,18 @@ export type ProductCategories = {
   product_id: string;
   category_id: string;
 };
+
+// 확장 타입 (supabase 원본 타입 아님)
+export type ProductCategoriesWithCategory = ProductCategories & {
+  categories: Pick<Categories, "id" | "name">;
+};
+
+// 확장 타입 (supabase 원본 타입 아님)
+export type ProductPreview = {
+  id: string;
+  name: string;
+  thumbnail_image: string;
+  price: number;
+  discount_rate: number;
+  product_categories: ProductCategoriesWithCategory[];
+};

--- a/src/app/lib/productLike.ts
+++ b/src/app/lib/productLike.ts
@@ -1,0 +1,6 @@
+export type ProductLike = {
+  id: string;
+  user_id: string;
+  product_id: string;
+  created_at: string;
+};

--- a/src/app/lib/productLike.ts
+++ b/src/app/lib/productLike.ts
@@ -1,6 +1,13 @@
+import { ProductPreview } from "./Categories";
+
 export type ProductLike = {
   id: string;
   user_id: string;
   product_id: string;
   created_at: string;
+};
+
+// 확장 타입
+export type ProductLikeWithProduct = ProductLike & {
+  products: ProductPreview;
 };

--- a/src/app/mypage/api/fetchLikes.ts
+++ b/src/app/mypage/api/fetchLikes.ts
@@ -1,0 +1,75 @@
+import { ProductLike } from "@/app/lib/productLike";
+import { createClient } from "../../../../utils/supabase/client";
+import {
+  ProductCategoriesWithCategory,
+  ProductPreview,
+} from "@/app/lib/Categories";
+
+// categories 포함된 products (UI용)
+export type ProductCategories = {
+  id: string;
+  product_id: string;
+  category_id: string;
+  categories: ProductCategoriesWithCategory;
+};
+
+// Supabase raw join 결과 타입
+type ProductLikeWithProductRaw = ProductLike & {
+  products: ProductPreview;
+};
+
+// 최종 UI 타입
+export type ProductLikeWithProduct = ProductLike & {
+  products: ProductPreview | ProductPreview[];
+};
+
+export const fetchLikes = async () => {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("product_likes")
+    .select(
+      `
+    id,
+    created_at,
+    user_id,
+    product_id,
+    products (
+      id,
+      name,
+      thumbnail_image,
+      price,
+      discount_rate,
+      product_categories (
+        id,
+        product_id,
+        category_id,
+        categories (id, name)
+      )
+    )
+  `,
+    )
+    .eq("user_id", user.id)
+    .returns<ProductLikeWithProductRaw[]>();
+
+  if (error) throw error;
+
+  const rows = data ?? [];
+
+  return rows.map((item) => {
+    const product = Array.isArray(item.products)
+      ? item.products[0]
+      : item.products;
+
+    return {
+      ...item,
+      products: product,
+    };
+  });
+};

--- a/src/app/mypage/components/MypageProductSkeleton.tsx
+++ b/src/app/mypage/components/MypageProductSkeleton.tsx
@@ -1,0 +1,35 @@
+type ProductListSkeletonProps = {
+  count?: number;
+};
+
+export default function MyPageProductSkeleton({
+  count = 9,
+}: ProductListSkeletonProps) {
+  return (
+    <section aria-labelledby="productListLoading" className="mt-15">
+      <h2 id="productListLoading" className="sr-only">
+        찜한 상품 목록 불러오는 중
+      </h2>
+
+      <ul className="grid grid-cols-3 gap-6">
+        {Array.from({ length: count }).map((_, i) => (
+          <li key={i} className="animate-pulse">
+            {/* 이미지 */}
+            <div className="aspect-square w-full bg-gray-200 rounded-lg" />
+
+            {/* 텍스트 */}
+            <div className="mt-3 space-y-2">
+              <div className="h-4 w-16 bg-gray-200 rounded" />
+              <div className="h-6 w-3/4 bg-gray-200 rounded" />
+
+              <div className="flex gap-2">
+                <div className="h-5 w-12 bg-gray-200 rounded" />
+                <div className="h-5 w-16 bg-gray-300 rounded" />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/mypage/consumer/wishlist/components/EmptyWishlist.tsx
+++ b/src/app/mypage/consumer/wishlist/components/EmptyWishlist.tsx
@@ -1,0 +1,7 @@
+export default function EmptyWishlist() {
+  return (
+    <div className="text-red-500 text-center pt-3">
+      <p>찜한 상품이 없습니다.</p>{" "}
+    </div>
+  );
+}

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
@@ -17,7 +17,7 @@ export default function WishListItemCard({ order, onRemove }: Props) {
   return (
     <div key={order.id} className="flex flex-col">
       <Link
-        href={`/products/pen/${order.id}`}
+        href={`/products/writing/${order.id}`}
         className="relative flex flex-col transition-transform duration-400 hover:scale-105"
       >
         {order.discountRate > 0 && (

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
@@ -1,7 +1,7 @@
 import LikeToggleButton from "@/app/mypage/consumer/wishlist/components/LikeToggleButton";
 import Link from "next/link";
 import Image from "next/image";
-import { ProductLikeWithProduct } from "./WishListItemsList";
+import { ProductLikeWithProduct } from "@/app/lib/productLike";
 
 interface Props {
   order: ProductLikeWithProduct;
@@ -12,7 +12,7 @@ export default function WishListItemCard({ order, onRemove }: Props) {
   return (
     <div key={order.id} className="flex flex-col">
       <Link
-        href={`/products/writing/${order.products.id}`}
+        href={`/products/${order.products.product_categories[0]?.categories.name}/${order.id}`}
         className="relative flex flex-col transition-transform duration-400 hover:scale-105"
       >
         {order.products.discount_rate > 0 && (
@@ -29,12 +29,14 @@ export default function WishListItemCard({ order, onRemove }: Props) {
           alt=""
         />
       </Link>
-      <div className="flex flex-col pr-4 pt-4">
+      <div className="flex flex-col  pt-4">
         <p className="text-sm text-gray-400 ">
           {order.products.product_categories[0]?.categories.name}
         </p>
         <div className="flex justify-between">
-          <p className="font-bold self-center">{order.products.name}</p>
+          <p className="font-bold self-center w-50 truncate">
+            {order.products.name}
+          </p>
           <LikeToggleButton id={order.id} onRemove={onRemove} />
         </div>
 

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
@@ -1,15 +1,10 @@
 import LikeToggleButton from "@/app/mypage/consumer/wishlist/components/LikeToggleButton";
 import Link from "next/link";
 import Image from "next/image";
-import { OrderItem } from "@/app/mypage/types/orderItem";
-
-const CATEGORY_TO_KOREAN: { writing: string; paper: string } = {
-  writing: "필기구",
-  paper: "노트/메모",
-};
+import { ProductLikeWithProduct } from "./WishListItemsList";
 
 interface Props {
-  order: OrderItem;
+  order: ProductLikeWithProduct;
   onRemove: (id: string) => void;
 }
 
@@ -17,12 +12,12 @@ export default function WishListItemCard({ order, onRemove }: Props) {
   return (
     <div key={order.id} className="flex flex-col">
       <Link
-        href={`/products/writing/${order.id}`}
+        href={`/products/writing/${order.products.id}`}
         className="relative flex flex-col transition-transform duration-400 hover:scale-105"
       >
-        {order.discountRate > 0 && (
+        {order.products.discount_rate > 0 && (
           <div className="absolute top-0 left-0  bg-[#DC2626] text-white px-2 py-1 text-sm font-bold">
-            {order.discountRate}%
+            {order.products.discount_rate}%
           </div>
         )}
 
@@ -30,27 +25,27 @@ export default function WishListItemCard({ order, onRemove }: Props) {
           width={282}
           height={282}
           className="object-fill "
-          src={order.image}
+          src={order.products.thumbnail_image}
           alt=""
         />
       </Link>
       <div className="flex flex-col pr-4 pt-4">
         <p className="text-sm text-gray-400 ">
-          {CATEGORY_TO_KOREAN[order.category]}
+          {order.products.product_categories[0]?.categories.name}
         </p>
         <div className="flex justify-between">
-          <p className="font-bold self-center">{order.name}</p>
+          <p className="font-bold self-center">{order.products.name}</p>
           <LikeToggleButton id={order.id} onRemove={onRemove} />
         </div>
 
         <div className="flex gap-2">
-          {order.discountRate > 0 && (
+          {order.products.discount_rate > 0 && (
             <span className="text-red-500 font-bold text-sm">
-              {order.discountRate}%
+              {order.products.discount_rate}%
             </span>
           )}
           <span className="font-bold text-sm text-slate-800">
-            {order.unitPrice.toLocaleString()}원
+            {order.products.price.toLocaleString()}원
           </span>
         </div>
       </div>

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -1,123 +1,101 @@
 "use client";
 
 import WishListItemCard from "./WishListItemsCard";
-import { useEffect, useState } from "react";
 import TabFilter from "./tabFilter";
 import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
 import { usePagination } from "@/hooks/usePagination";
 import { createClient } from "../../../../../../utils/supabase/client";
-import { ProductLike } from "@/app/lib/productLike";
-
-// 카드 미리보기 용 타입
-type ProductPreview = {
-  id: string;
-  name: string;
-  thumbnail_image: string;
-  price: number;
-  discount_rate: number;
-
-  product_categories: {
-    categories: {
-      id: string;
-      name: string;
-    };
-  }[];
-};
-
-// 기본 찜한 상품 타입 & join 용 타입 추가
-export type ProductLikeWithProduct = ProductLike & {
-  products: ProductPreview;
-};
-
-const CATEGORIES = [
-  { id: "", label: "전체" },
-  { id: "필기구", label: "필기구" },
-  { id: "노트/메모", label: "노트/메모" },
-];
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchLikes } from "@/app/mypage/api/fetchLikes";
+import { ProductLikeWithProduct } from "@/app/lib/productLike";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const supabase = createClient();
 
 export default function WishListItemsList() {
-  const [items, setItems] = useState<ProductLikeWithProduct[]>([]);
-  const [selectedValue, setSelectedValue] = useState("");
-  const [sortValue, setSortValue] = useState("lastProduct");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const category = searchParams.get("category") ?? "all";
+  const sort = searchParams.get("sort") ?? "latest";
+  const page = Number(searchParams.get("page") ?? 1);
+  const queryClient = useQueryClient();
+
+  const onChangeCategory = (slug: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set("category", slug);
+    params.set("page", "1"); // 필터 바꾸면 페이지 초기화
+
+    router.push(`?${params.toString()}`);
+  };
+
+  const onChangeSort = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set("sort", value);
+    params.set("page", "1");
+
+    router.push(`?${params.toString()}`);
+  };
+
+  const onChangePage = (newPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set("page", String(newPage));
+
+    router.push(`?${params.toString()}`);
+  };
+
+  // 데이터 가져오기 useQuery
+  const { data: items = [] } = useQuery<ProductLikeWithProduct[]>({
+    queryKey: ["likes"],
+    queryFn: fetchLikes,
+  });
+
+  // 아이템의 찜하기 버튼 해체 시 해당 아이템 카드 사라지게 하기
+  const onRemove = async (id: string) => {
+    await supabase.from("product_likes").delete().eq("id", id);
+
+    queryClient.invalidateQueries({ queryKey: ["likes"] });
+  };
+
+  // 데이터에서 카테고리 네임 자동 탭 설정
+  const categoryTabs = [
+    { id: "all", label: "전체" },
+
+    //  items → product_categories → categories.name 전부 추출
+    ...Array.from(
+      new Set(
+        items.flatMap((item) =>
+          item.products.product_categories.map((pc) => pc.categories.name),
+        ),
+      ),
+    ).map((name) => ({
+      // id = 실제 필터 기준값 (DB name 그대로 사용)
+      // label = 화면에 보여질 값
+      id: name,
+      label: name,
+    })),
+  ];
 
   const filteredItems = items.filter((item) => {
-    if (!selectedValue) return true;
+    if (category === "all") return true;
 
-    // 여러 카테고리를 찾아주기
     return item.products.product_categories.some(
-      (pc) => pc.categories.name === selectedValue,
+      (pc) => pc.categories.name === category,
     );
   });
 
-  // 데이터 가져오기
-  useEffect(() => {
-    const fetchLikes = async () => {
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (userError) {
-        console.error(userError);
-        return;
-      }
-
-      if (!user) {
-        console.log("로그인된 유저 없음");
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from("product_likes")
-        .select(
-          `
-        id,
-        created_at,
-        user_id,
-        product_id,
-        products (
-          id,
-          name,
-          thumbnail_image,
-          price,
-          discount_rate,
-          product_categories (
-            categories (
-              id,
-              name
-            )
-          )
-        )
-      `,
-        )
-
-        .returns<ProductLikeWithProduct[]>();
-
-      console.log(data);
-
-      if (error) {
-        console.error(error);
-        return;
-      }
-
-      setItems(data ?? []);
-    };
-
-    fetchLikes();
-  }, []);
-
   // 정렬할 아이템
   const sortedItems = filteredItems.toSorted((a, b) => {
-    switch (sortValue) {
-      case "highPriceProduct":
+    switch (sort) {
+      case "price-high":
         return b.products.price - a.products.price;
 
-      case "lowPriceProduct":
+      case "price-low":
         return a.products.price - b.products.price;
 
-      case "lastProduct":
+      case "latest":
         return (
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
         );
@@ -128,25 +106,15 @@ export default function WishListItemsList() {
   });
 
   // 페이지네이션 로직
-  const { currentItems, currentPage, setCurrentPage, totalPages } =
-    usePagination(sortedItems, 9);
-
-  // 아이템의 찜하기 버튼 해체 시 해당 아이템 카드 사라지게 하기
-  const onRemove = (id: string) => {
-    const newFilterValue = items.filter((item) => item.id !== id);
-    setItems(newFilterValue);
-
-    // 다 삭제한 후에 페이지를 보정해주기
-    setCurrentPage(1);
-  };
+  const { currentItems, totalPages } = usePagination(sortedItems, 9, page);
 
   return (
     <>
       <div className="flex justify-between ">
         <TabFilter
-          items={CATEGORIES}
-          selectedValue={selectedValue}
-          onValueChange={setSelectedValue}
+          items={categoryTabs}
+          selectedValue={category}
+          onValueChange={onChangeCategory}
         />
         <label htmlFor="filter" className="sr-only">
           필터
@@ -155,12 +123,12 @@ export default function WishListItemsList() {
           name="filter"
           id="filter"
           className="border border-gray-400 h-9 px-2 "
-          value={sortValue}
-          onChange={(e) => setSortValue(e.target.value)}
+          value={sort}
+          onChange={(e) => onChangeSort(e.target.value)}
         >
-          <option value="lastProduct">등록순</option>
-          <option value="highPriceProduct">가격 높은 순</option>
-          <option value="lowPriceProduct">가격 낮은 순</option>
+          <option value="latest">등록순</option>
+          <option value="price-high">가격 높은 순</option>
+          <option value="price-low">가격 낮은 순</option>
         </select>
       </div>
       <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6  gap-y-15 ">
@@ -171,9 +139,9 @@ export default function WishListItemsList() {
         ))}
       </ul>
       <Pagination
-        currentPage={currentPage}
+        currentPage={page}
         totalPages={totalPages}
-        onPageChange={setCurrentPage}
+        onPageChange={onChangePage}
       />
     </>
   );

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -126,7 +126,7 @@ export default function WishListItemsList() {
           value={sort}
           onChange={(e) => onChangeSort(e.target.value)}
         >
-          <option value="latest">등록순</option>
+          <option value="latest">최신순</option>
           <option value="price-high">가격 높은 순</option>
           <option value="price-low">가격 낮은 순</option>
         </select>

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -1,28 +1,143 @@
 "use client";
 
 import WishListItemCard from "./WishListItemsCard";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import TabFilter from "./tabFilter";
 import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
 import { usePagination } from "@/hooks/usePagination";
-import { dummyOrderItems } from "@/data/dummyOrder";
+import { createClient } from "../../../../../../utils/supabase/client";
+import { ProductLike } from "@/app/lib/productLike";
+
+// 카드 미리보기 용 타입
+type ProductPreview = {
+  id: string;
+  name: string;
+  thumbnail_image: string;
+  price: number;
+  discount_rate: number;
+
+  product_categories: {
+    categories: {
+      id: string;
+      name: string;
+    };
+  }[];
+};
+
+// 기본 찜한 상품 타입 & join 용 타입 추가
+export type ProductLikeWithProduct = ProductLike & {
+  products: ProductPreview;
+};
 
 const CATEGORIES = [
   { id: "", label: "전체" },
-  { id: "writing", label: "필기구" },
-  { id: "paper", label: "노트/메모" },
+  { id: "필기구", label: "필기구" },
+  { id: "노트/메모", label: "노트/메모" },
 ];
 
+const supabase = createClient();
+
 export default function WishListItemsList() {
+  const [items, setItems] = useState<ProductLikeWithProduct[]>([]);
   const [selectedValue, setSelectedValue] = useState("");
-  const [filterValue, setFilterValue] = useState([...dummyOrderItems]);
+  const [sortValue, setSortValue] = useState("lastProduct");
 
+  const filteredItems = items.filter((item) => {
+    if (!selectedValue) return true;
+
+    // 여러 카테고리를 찾아주기
+    return item.products.product_categories.some(
+      (pc) => pc.categories.name === selectedValue,
+    );
+  });
+
+  // 데이터 가져오기
+  useEffect(() => {
+    const fetchLikes = async () => {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+
+      if (userError) {
+        console.error(userError);
+        return;
+      }
+
+      if (!user) {
+        console.log("로그인된 유저 없음");
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from("product_likes")
+        .select(
+          `
+        id,
+        created_at,
+        user_id,
+        product_id,
+        products (
+          id,
+          name,
+          thumbnail_image,
+          price,
+          discount_rate,
+          product_categories (
+            categories (
+              id,
+              name
+            )
+          )
+        )
+      `,
+        )
+
+        .returns<ProductLikeWithProduct[]>();
+
+      console.log(data);
+
+      if (error) {
+        console.error(error);
+        return;
+      }
+
+      setItems(data ?? []);
+    };
+
+    fetchLikes();
+  }, []);
+
+  // 정렬할 아이템
+  const sortedItems = filteredItems.toSorted((a, b) => {
+    switch (sortValue) {
+      case "highPriceProduct":
+        return b.products.price - a.products.price;
+
+      case "lowPriceProduct":
+        return a.products.price - b.products.price;
+
+      case "lastProduct":
+        return (
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+
+      default:
+        return 0;
+    }
+  });
+
+  // 페이지네이션 로직
   const { currentItems, currentPage, setCurrentPage, totalPages } =
-    usePagination(filterValue, 9);
+    usePagination(sortedItems, 9);
 
+  // 아이템의 찜하기 버튼 해체 시 해당 아이템 카드 사라지게 하기
   const onRemove = (id: string) => {
-    const newFilterValue = filterValue.filter((item) => item.id !== id);
-    setFilterValue(newFilterValue);
+    const newFilterValue = items.filter((item) => item.id !== id);
+    setItems(newFilterValue);
+
+    // 다 삭제한 후에 페이지를 보정해주기
+    setCurrentPage(1);
   };
 
   return (
@@ -39,10 +154,11 @@ export default function WishListItemsList() {
         <select
           name="filter"
           id="filter"
-          className="border border-gray-400 h-9 "
+          className="border border-gray-400 h-9 px-2 "
+          value={sortValue}
+          onChange={(e) => setSortValue(e.target.value)}
         >
           <option value="lastProduct">등록순</option>
-          <option value="popularProduct">인기순</option>
           <option value="highPriceProduct">가격 높은 순</option>
           <option value="lowPriceProduct">가격 낮은 순</option>
         </select>

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -9,6 +9,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchLikes } from "@/app/mypage/api/fetchLikes";
 import { ProductLikeWithProduct } from "@/app/lib/productLike";
 import { useRouter, useSearchParams } from "next/navigation";
+import EmptyWishlist from "./EmptyWishlist";
 
 const supabase = createClient();
 
@@ -51,6 +52,7 @@ export default function WishListItemsList() {
     queryKey: ["likes"],
     queryFn: fetchLikes,
   });
+  const hasItems = items.length > 0;
 
   // 아이템의 찜하기 버튼 해체 시 해당 아이템 카드 사라지게 하기
   const onRemove = async (id: string) => {
@@ -131,18 +133,25 @@ export default function WishListItemsList() {
           <option value="price-low">가격 낮은 순</option>
         </select>
       </div>
-      <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6  gap-y-15 ">
-        {currentItems.map((item) => (
-          <li key={item.id}>
-            <WishListItemCard order={item} onRemove={onRemove} />
-          </li>
-        ))}
-      </ul>
-      <Pagination
-        currentPage={page}
-        totalPages={totalPages}
-        onPageChange={onChangePage}
-      />
+      {hasItems ? (
+        <>
+          <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-15">
+            {currentItems.map((item) => (
+              <li key={item.id}>
+                <WishListItemCard order={item} onRemove={onRemove} />
+              </li>
+            ))}
+          </ul>
+
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={onChangePage}
+          />
+        </>
+      ) : (
+        <EmptyWishlist />
+      )}
     </>
   );
 }

--- a/src/app/mypage/consumer/wishlist/page.tsx
+++ b/src/app/mypage/consumer/wishlist/page.tsx
@@ -1,5 +1,7 @@
+import { Suspense } from "react";
 import WishListItemsList from "./components/WishListItemsList";
 import { dummyOrderItems } from "@/data/dummyOrder";
+import MyPageProductSkeleton from "../../components/MypageProductSkeleton";
 
 const HAS_WISH_PRODUCTS = dummyOrderItems.length > 0;
 
@@ -8,7 +10,9 @@ export default function WishlistPage() {
     <div className="w-full bg-white pt-6 px-6 pb-11.25 ">
       <h1 className="text-2xl font-bold mb-8 sr-only">찜한 상품</h1>
       {HAS_WISH_PRODUCTS ? (
-        <WishListItemsList />
+        <Suspense fallback={<MyPageProductSkeleton count={9} />}>
+          <WishListItemsList />
+        </Suspense>
       ) : (
         <div className="text-red-500 text-center pt-3">
           <p>찜한 상품이 없습니다.</p>{" "}

--- a/src/app/mypage/consumer/wishlist/page.tsx
+++ b/src/app/mypage/consumer/wishlist/page.tsx
@@ -1,23 +1,14 @@
 import { Suspense } from "react";
 import WishListItemsList from "./components/WishListItemsList";
-import { dummyOrderItems } from "@/data/dummyOrder";
 import MyPageProductSkeleton from "../../components/MypageProductSkeleton";
-
-const HAS_WISH_PRODUCTS = dummyOrderItems.length > 0;
 
 export default function WishlistPage() {
   return (
     <div className="w-full bg-white pt-6 px-6 pb-11.25 ">
       <h1 className="text-2xl font-bold mb-8 sr-only">찜한 상품</h1>
-      {HAS_WISH_PRODUCTS ? (
-        <Suspense fallback={<MyPageProductSkeleton count={9} />}>
-          <WishListItemsList />
-        </Suspense>
-      ) : (
-        <div className="text-red-500 text-center pt-3">
-          <p>찜한 상품이 없습니다.</p>{" "}
-        </div>
-      )}
+      <Suspense fallback={<MyPageProductSkeleton count={9} />}>
+        <WishListItemsList />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,6 +1,7 @@
 import SideMenu from "./components/SideMenu";
 import SummaryMenu from "./components/SummaryMenu";
 import UserProfile from "./components/UserProfile";
+import MypageProviders from "./providers/MypageProviders";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -17,7 +18,7 @@ export default function MyPageLayout({ children }: LayoutProps) {
         <main className="flex-1 mb-20">
           <div className="flex flex-col gap-6">
             <SummaryMenu />
-            {children}
+            <MypageProviders>{children}</MypageProviders>
           </div>
         </main>
       </div>

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -14,7 +14,7 @@ export default function MyPageLayout({ children }: LayoutProps) {
           <UserProfile />
           <SideMenu />
         </aside>
-        <main className="flex-1">
+        <main className="flex-1 mb-20">
           <div className="flex flex-col gap-6">
             <SummaryMenu />
             {children}

--- a/src/app/mypage/providers/MypageProviders.tsx
+++ b/src/app/mypage/providers/MypageProviders.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export default function MypageProviders({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60 * 5, // 5분 캐시 유지
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/app/mypage/seller/register/actions/registerProduct.ts
+++ b/src/app/mypage/seller/register/actions/registerProduct.ts
@@ -86,7 +86,7 @@ async function processRegister(formData: FormData): Promise<FormState> {
     errors.productOptions = "옵션 데이터가 올바르지 않습니다.";
   }
 
-  // 👉 에러 하나라도 있으면 반환
+  // 에러 하나라도 있으면 반환
   if (Object.keys(errors).length > 0) {
     return { errors };
   }

--- a/src/app/mypage/types/productLike.ts
+++ b/src/app/mypage/types/productLike.ts
@@ -1,6 +1,0 @@
-export interface ProductLike {
-  id: string;       
-  user_id: string;     
-  product_id: string;
-  created_at: string; 
-}

--- a/src/data/dummyOrder.ts
+++ b/src/data/dummyOrder.ts
@@ -2,7 +2,7 @@ import type { OrderItem } from "@/app/mypage/types/orderItem";
 
 export const dummyOrderItems: OrderItem[] = [
   {
-    id: "item-1",
+    id: "1",
     orderId: "ORD-001",
     userId: "김근영",
     productId: "prod-1",
@@ -16,7 +16,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-2",
+    id: "2",
     orderId: "ORD-001",
     userId: "김근영",
     productId: "prod-2",
@@ -30,7 +30,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-3",
+    id: "3",
     orderId: "ORD-002",
     userId: "장예지",
     productId: "prod-3",
@@ -44,7 +44,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-4",
+    id: "4",
     orderId: "ORD-002",
     userId: "장예지",
     productId: "prod-4",
@@ -58,7 +58,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-5",
+    id: "5",
     orderId: "ORD-003",
     userId: "송하늬",
     productId: "prod-5",
@@ -72,7 +72,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-6",
+    id: "6",
     orderId: "ORD-004",
     userId: "박성윤",
     productId: "prod-6",
@@ -86,7 +86,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-7",
+    id: "7",
     orderId: "ORD-005",
     userId: "이동헌",
     productId: "prod-7",
@@ -100,7 +100,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-8",
+    id: "8",
     orderId: "ORD-005",
     userId: "이동헌",
     productId: "prod-8",
@@ -114,7 +114,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-9",
+    id: "9",
     orderId: "ORD-006",
     userId: "김근영",
     productId: "prod-9",
@@ -128,7 +128,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-10",
+    id: "10",
     orderId: "ORD-007",
     userId: "장예지",
     productId: "prod-10",
@@ -142,7 +142,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-11",
+    id: "11",
     orderId: "ORD-007",
     userId: "장예지",
     productId: "prod-11",
@@ -156,7 +156,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-12",
+    id: "12",
     orderId: "ORD-008",
     userId: "송하늬",
     productId: "prod-12",
@@ -170,7 +170,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-13",
+    id: "13",
     orderId: "ORD-009",
     userId: "박성윤",
     productId: "prod-13",
@@ -184,7 +184,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-14",
+    id: "14",
     orderId: "ORD-010",
     userId: "이동헌",
     productId: "prod-14",
@@ -198,7 +198,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-15",
+    id: "15",
     orderId: "ORD-010",
     userId: "이동헌",
     productId: "prod-15",
@@ -212,7 +212,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-16",
+    id: "16",
     orderId: "ORD-011",
     userId: "김근영",
     productId: "prod-16",
@@ -226,7 +226,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-17",
+    id: "17",
     orderId: "ORD-011",
     userId: "김근영",
     productId: "prod-17",
@@ -240,7 +240,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-18",
+    id: "18",
     orderId: "ORD-012",
     userId: "장예지",
     productId: "prod-18",
@@ -254,7 +254,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-19",
+    id: "19",
     orderId: "ORD-012",
     userId: "장예지",
     productId: "prod-19",
@@ -268,7 +268,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-20",
+    id: "20",
     orderId: "ORD-013",
     userId: "송하늬",
     productId: "prod-20",
@@ -282,7 +282,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-21",
+    id: "21",
     orderId: "ORD-014",
     userId: "박성윤",
     productId: "prod-21",
@@ -296,7 +296,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-22",
+    id: "22",
     orderId: "ORD-015",
     userId: "이동헌",
     productId: "prod-22",
@@ -310,7 +310,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-23",
+    id: "23",
     orderId: "ORD-015",
     userId: "이동헌",
     productId: "prod-23",
@@ -324,7 +324,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-24",
+    id: "24",
     orderId: "ORD-016",
     userId: "김근영",
     productId: "prod-24",
@@ -338,7 +338,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-25",
+    id: "25",
     orderId: "ORD-017",
     userId: "장예지",
     productId: "prod-25",
@@ -351,9 +351,8 @@ export const dummyOrderItems: OrderItem[] = [
     orderDate: "2026-03-31",
     category: "writing",
   },
-
   {
-    id: "item-26",
+    id: "26",
     orderId: "ORD-018",
     userId: "송하늬",
     productId: "prod-26",
@@ -367,7 +366,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-27",
+    id: "27",
     orderId: "ORD-018",
     userId: "송하늬",
     productId: "prod-27",
@@ -381,7 +380,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-28",
+    id: "28",
     orderId: "ORD-019",
     userId: "박성윤",
     productId: "prod-28",
@@ -395,7 +394,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-29",
+    id: "29",
     orderId: "ORD-020",
     userId: "이동헌",
     productId: "prod-29",
@@ -409,7 +408,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-30",
+    id: "30",
     orderId: "ORD-021",
     userId: "김근영",
     productId: "prod-30",
@@ -422,9 +421,8 @@ export const dummyOrderItems: OrderItem[] = [
     orderDate: "2026-04-07",
     category: "writing",
   },
-
   {
-    id: "item-31",
+    id: "31",
     orderId: "ORD-022",
     userId: "장예지",
     productId: "prod-31",
@@ -438,7 +436,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-32",
+    id: "32",
     orderId: "ORD-023",
     userId: "송하늬",
     productId: "prod-32",
@@ -452,7 +450,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-33",
+    id: "33",
     orderId: "ORD-024",
     userId: "박성윤",
     productId: "prod-33",
@@ -466,7 +464,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "writing",
   },
   {
-    id: "item-34",
+    id: "34",
     orderId: "ORD-025",
     userId: "이동헌",
     productId: "prod-34",
@@ -480,7 +478,7 @@ export const dummyOrderItems: OrderItem[] = [
     category: "paper",
   },
   {
-    id: "item-35",
+    id: "35",
     orderId: "ORD-026",
     userId: "김근영",
     productId: "prod-35",

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,17 +1,15 @@
-"use client";
-import { useState } from "react";
-
-export function usePagination<T>(data: T[], itemsPerPage: number) {
-  const [currentPage, setCurrentPage] = useState(1);
-
+export function usePagination<T>(
+  data: T[],
+  itemsPerPage: number,
+  currentPage: number,
+) {
   const totalPages = Math.ceil(data.length / itemsPerPage);
 
   const start = (currentPage - 1) * itemsPerPage;
+
   const currentItems = data.slice(start, start + itemsPerPage);
 
   return {
-    currentPage,
-    setCurrentPage,
     totalPages,
     currentItems,
   };


### PR DESCRIPTION
### **PR 유형**

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**

- 

### **PR 상세**
#### 1. 찜한 상품 목록 조회
Supabase에서 찜한 상품 데이터를 가져오고 상품 정보까지 함께 조회해서 화면에 표시했습니다. 초기에는 join 결과가 배열 또는 단일 객체로 섞여 있어 타입 에러가 발생했습니다. Array.isArray로 데이터를 하나의 형태로 정리해서 안정적으로 렌더링되도록 수정했습니다.

#### 2. React Query 적용 이유 및 데이터 관리
찜한 상품 데이터는 서버 상태이기 때문에 React Query를 적용했습니다. React Query를 사용하면서 데이터 캐싱이 적용되어 불필요한 API 요청을 줄일 수 있었습니다. 삭제 후 invalidateQueries를 통해 최신 데이터를 다시 불러오도록 해서 서버 데이터와 UI 상태를 일치시켰습니다.

#### 3. 카테고리 필터 기능 및  목록 자동 생성
상품에 연결된 카테고리 name을 기준으로 필터 기능을 구현했습니다.초기에는 slug, id, name이 섞여 있어 필터가 정상 동작하지 않는 문제가 있었습니다. DB의 category name 기준으로 통일하여 해당 데이터 카테고리 이름에 따라 자동으로 필터가 생성되는 방향으로 구현하였습니다.

#### 4. 정렬 기능
가격 높은 순, 낮은 순, 최신순으로 정렬 기능을 구현했습니다. 초기에는 sort 값이 일관되지 않아 일부 정렬이 정상 동작하지 않는 문제가 있었습니다. sort 값을 기준으로 switch문으로 수정하여 진행하였습니다.

#### 5. URL 기반 상태 관리 (카테고리 / 정렬 / 페이지)
상태와 URL이 따로 관리되면서 화면과 데이터가 일치하지 않는 부분을 보완하기 위해, 카테고리, 정렬, 페이지 상태를 URL query로 관리하도록 변경했습니다. 

⚠️ 추가 사항 (URL에 한국어 사용 관련)
현재 URL의 category 값이 DB의 한국어 name을 그대로 사용하고 있습니다. 가독성이 떨어지고, 인코딩 문제 및 공유 시 불편함이 발생할 수 있다는 단점이 있다고 생각합니다. 따라서 추후에는 시간적 여유가 된다면 리팩토링할 예정입니다.

#### 6. 찜하기 삭제 기능
찜하기 해제 시 Supabase에서 해당 데이터가 삭제되도록 구현했습니다. 콘솔을 통해 id와 user_id 모두 정상적으로 조회되는 것을 확인했지만, 실제 화면에서는 삭제 후 반영되지 않는 문제가 있었습니다.
해당 원인은 Supabase 정책 설정이 적용되지 않았거나 조건이 맞지 않을 가능성이 높다고 판단되며, 현재 구조에서는 삭제는 수행되지만 조회 결과에 반영되지 않는 상태로 보입니다. 이 부분은 추후 수정 작업이 필요할 것 같습니다.

#### 7. 타입 구조 확장
카테고리 기준이 여러 방식으로 나뉘어 있어 필터 로직이 복잡했습니다. 또한 supabase에 원본 데이터 타입 중에 사용하지 않는 키값을 고려하여 lib 폴더 안의 productLikes와 Categories 내부의 원본 데이터 타입을 확장하여 만든 커스텀 타입 또한 넣어놓았습니다. 혹여나 사용에 혼란을 드릴 수 있어, 확장 타입인 경우에는 주석을 추가하여, 원본 데이터 타입과 구분을 하였습니다. 

#### 8. 찜한 상품 유무에 따른 조건부 렌더링
기존에는 더미데이터를 활용하여 찜한 상품 페이지에서 조건부로 렌더링을 하였습니다. 이번에 찜한 상품 로직을 추가함으로써, wishlist 컴포넌트에서  reactQuery가 관리하는 데이터의 길이를 확인하는 과정을 통해 조건부 렌더링을 해주는 로직 흐름으로 수정하였습니다. 상품이 없을 "찜한 상품이 없습니다." 라는 문구가 나오는 EmptyWilshlist.tsx도 추가하였습니다.



<br/>
** 추가로 찜하기 버튼은 마이페이지에서는 해제 시 나의 찜한 상품 페이지에서 제거가 되는 로직이 연결되어져 있습니다. 반면에 하늬님과 성윤님의 찜하기 버튼은 찜하기 버튼 클릭 시 찜한 상품 데이터에 저장이 되어야 하므로, 제가 만든 찜하기 버튼을 재사용을 하기는 어려울 것 같다는 생각이 들어 몇 줄 남겨봅니다!



---
<br/>
<img width="2243" height="2464" alt="image" src="https://github.com/user-attachments/assets/d3a7b860-de25-43c0-b564-7119a7448927" />

<br/><br/>
<img width="670" height="265" alt="스크린샷 2026-05-08 오전 9 11 40" src="https://github.com/user-attachments/assets/be84e4a1-387e-41c5-a824-86e64dfa2148" />


### **이슈번호 # 102**
