### PR TITLE
[FIX] 113 ImageUploader 컴포넌트의 빈 src 전달 에러 수정

### DIFF
--- a/src/app/mypage/consumer/profile/components/ImageUploader.tsx
+++ b/src/app/mypage/consumer/profile/components/ImageUploader.tsx
@@ -10,10 +10,11 @@ interface ImageUploaderProps {
 
 export default function ImageUploader({
   label,
-  defaultImage = "/",
+  defaultImage = "", // 기본값을 빈 문자열로 설정하여 에러 방지
 }: ImageUploaderProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string>(defaultImage);
+
   const handleButtonClick = () => {
     fileInputRef.current?.click();
   };
@@ -29,18 +30,41 @@ export default function ImageUploader({
     }
   };
 
+  // 이미지 경로가 유효한지 체크 (빈 문자열이거나 "/"인 경우 제외)
+  const isImageValid = preview && preview !== "" && preview !== "/";
+
   return (
     <div className="flex flex-col gap-3 w-full">
       <span className="text-sm font-semibold text-gray-700 ml-1">{label}</span>
 
       <div className="flex items-center gap-4">
         <div className="relative w-24 aspect-square overflow-hidden border border-gray-200 bg-gray-50 flex items-center justify-center">
-          <Image
-            src={preview}
-            alt="프로필 미리보기"
-            fill
-            className="object-cover"
-          />
+          {/* 이미지가 유효할 때만 Image 컴포넌트 출력 */}
+          {isImageValid ? (
+            <Image
+              src={preview}
+              alt="프로필 미리보기"
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex flex-col items-center justify-center text-gray-400">
+              <svg
+                className="w-8 h-8 mb-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <span className="text-xs">No Image</span>
+            </div>
+          )}
         </div>
         <button
           type="button"


### PR DESCRIPTION

### **PR 유형**

- [X]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### **PR 체크리스트**
- [x] 이미지 업로더 컴포넌트에서 src 에 빈 문자열 및 / 가 전달되어 에러로 인해 페이지 렌더링이 되지 않는 문제를 해결

### **PR 상세**
- 조건부 렌더링 적용 (이미지가 있을 때만 <Image /> 출력)
- 기본값 설정 및 src="" 전달 방지
- 이미지 경로 유효성 검사 로직 추가 (빈 문자열 및 "/" 체크) -> 유효성 검사에서 통과하지 못하면 이미지 대신 default 아이콘과 no image 문구가 렌더링됨

### **이슈번호 #113 **
