### PR TITLE
Feat 131 마이페이지 나의 주문 상품 슈파베이스 연동 및 로직 추가

### DIFF
--- a/src/app/lib/Categories.ts
+++ b/src/app/lib/Categories.ts
@@ -25,3 +25,10 @@ export type ProductPreview = {
   discount_rate: number;
   product_categories: ProductCategoriesWithCategory[];
 };
+
+export type OrderProducts = {
+  id: string;
+  name: string;
+  thumbnail_image: string;
+  product_categories: ProductCategoriesWithCategory[];
+};

--- a/src/app/lib/Orders.ts
+++ b/src/app/lib/Orders.ts
@@ -1,3 +1,5 @@
+import { OrderProducts } from "./Categories";
+
 export type Orders = {
   id: string;
   user_id: string;
@@ -20,4 +22,22 @@ export type Order_items = {
   unit_price: number;
   invoice_number: string;
   item_status: string;
+};
+
+// 확장 타입
+export type OrderItem = {
+  id: string;
+  product_id: string;
+  quantity: number;
+  unit_price: number;
+  item_status: string;
+  products: OrderProducts;
+};
+
+export type OrdersType = {
+  id: string;
+  order_status: string;
+  final_price: number;
+  created_at: string;
+  order_items: OrderItem[];
 };

--- a/src/app/lib/Orders.ts
+++ b/src/app/lib/Orders.ts
@@ -1,7 +1,7 @@
 export type Orders = {
   id: string;
   user_id: string;
-  order_state: string;
+  order_status: string;
   total_price: number;
   used_coupon_id: string;
   discount_amount: number;

--- a/src/app/mypage/api/fetchOrders.ts
+++ b/src/app/mypage/api/fetchOrders.ts
@@ -1,0 +1,46 @@
+import { createClient } from "../../../../utils/supabase/client";
+
+export const fetchOrders = async () => {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("orders")
+    .select(
+      `
+    id,
+    order_status,
+    final_price,
+    created_at,
+
+    order_items (
+      id,
+      product_id,
+      quantity,
+      unit_price,
+      item_status,
+
+      products (
+        id,
+        name,
+        thumbnail_image,
+
+        product_categories (
+          categories (
+            id,
+            name
+          )
+        )
+      )
+    )
+  `,
+    )
+    .eq("user_id", user.id);
+
+  if (error) throw error;
+  return data;
+};

--- a/src/app/mypage/api/fetchOrders.ts
+++ b/src/app/mypage/api/fetchOrders.ts
@@ -1,3 +1,4 @@
+import { OrdersType } from "@/app/lib/Orders";
 import { createClient } from "../../../../utils/supabase/client";
 
 export const fetchOrders = async () => {
@@ -39,8 +40,9 @@ export const fetchOrders = async () => {
     )
   `,
     )
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .returns<OrdersType[]>();
 
   if (error) throw error;
-  return data;
+  return data ?? [];
 };

--- a/src/app/mypage/components/MypageOrdersSkeleton.tsx
+++ b/src/app/mypage/components/MypageOrdersSkeleton.tsx
@@ -1,0 +1,44 @@
+type ProductListSkeletonProps = {
+  count?: number;
+};
+
+export default function MyPageOrdersSkeleton({
+  count = 9,
+}: ProductListSkeletonProps) {
+  return (
+    <section aria-labelledby="orderListLoading" className="mt-10">
+      <h2 id="orderListLoading" className="sr-only">
+        주문 목록 불러오는 중
+      </h2>
+
+      <div className="border-t border-gray-300">
+        {Array.from({ length: count }).map((_, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[2fr_1fr_1fr_140px] items-center py-10 border-b border-gray-200 animate-pulse"
+          >
+            {/* 상품 정보 */}
+            <div className="flex items-center gap-6">
+              <div className="w-30 h-30 bg-gray-200 rounded-md" />
+
+              <div className="space-y-3">
+                <div className="h-6 w-48 bg-gray-200 rounded" />
+                <div className="h-4 w-28 bg-gray-100 rounded" />
+              </div>
+            </div>
+
+            <div className="flex justify-center">
+              <div className="h-6 w-28 bg-gray-200 rounded" />
+            </div>
+            <div className="flex justify-center">
+              <div className="h-6 w-24 bg-gray-200 rounded" />
+            </div>
+            <div className="flex justify-center">
+              <div className="h-12 w-28 bg-gray-200 rounded-lg" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
@@ -34,30 +34,30 @@ export default function OrderItemCard({
           href={{
             pathname: `/products/${categoryId}/${productId}`,
           }}
-          className="flex flex-row gap-4"
+          className="flex flex-row gap-4 shrink-0"
         >
           <Image
             width={80}
             height={80}
-            className="object-fill"
+            className="object-fill shrink-0"
             src={order.products.thumbnail_image}
             alt=""
           />
-          <h2 className="self-center hover:text-red-500 hover:font-extrabold">
+          <h2 className="self-center truncate  hover:text-red-500 hover:font-extrabold">
             {order.products.name}
           </h2>
         </Link>
       </div>
       {/* 주문 일자 */}
-      <div className="flex gap-3 w-1/6">
+      <div className="flex gap-3 w-1/6 items-center shrink-0 whitespace-nowrap">
         <p>{new Date(createdAt).toLocaleDateString("ko-KR")}</p>
       </div>
       {/* 결제 금액 */}
-      <div className="flex gap-3 w-1/6">
+      <div className="flex gap-3 w-1/6 items-center shrink-0 whitespace-nowrap">
         <p>{finalPrice.toLocaleString()}원</p>
       </div>
       {/* 배송 상태  */}
-      <div className="flex gap-3 w-1/6">
+      <div className="flex gap-3 w-1/6 items-center shrink-0 whitespace-nowrap">
         <OrderStatusBadge status={orderStatus as OrderItemStatus} />
       </div>
     </div>

--- a/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderItemCard.tsx
@@ -1,40 +1,64 @@
-import { OrderItem } from "@/app/mypage/types/orderItem";
 import OrderStatusBadge from "./OrderStatusBadge";
 import Image from "next/image";
 import Link from "next/link";
+import { OrderItemStatus } from "../lib/orderItemStatus";
+import { CATEGORY_GROUPS } from "../../wishlist/lib/categoryGroup";
+import { OrderItem } from "@/app/lib/Orders";
 
-export default function OrderItemCard({ order }: { order: OrderItem }) {
+interface Props {
+  order: OrderItem;
+  createdAt: string;
+  finalPrice: number;
+  orderStatus: string;
+}
+
+export default function OrderItemCard({
+  order,
+  createdAt,
+  finalPrice,
+  orderStatus,
+}: Props) {
+  const categoryName = order.products.product_categories[0].categories.name;
+
+  const categoryId = CATEGORY_GROUPS.find((group) =>
+    group.categories.includes(categoryName),
+  )?.id;
+
+  const productId = order.product_id;
+
   return (
     <div className="flex font-semibold p-4 mb-2 border-b border-gray-300 ">
       {/* 상품 이미지 및 정보 */}
       <div className="flex w-3/6 ">
         <Link
-          href={`/products/pen/${order.id}`}
+          href={{
+            pathname: `/products/${categoryId}/${productId}`,
+          }}
           className="flex flex-row gap-4"
         >
           <Image
             width={80}
             height={80}
             className="object-fill"
-            src={order.image}
+            src={order.products.thumbnail_image}
             alt=""
           />
           <h2 className="self-center hover:text-red-500 hover:font-extrabold">
-            {order.name}
+            {order.products.name}
           </h2>
         </Link>
       </div>
       {/* 주문 일자 */}
       <div className="flex gap-3 w-1/6">
-        <p>{order.orderDate}</p>
+        <p>{new Date(createdAt).toLocaleDateString("ko-KR")}</p>
       </div>
       {/* 결제 금액 */}
       <div className="flex gap-3 w-1/6">
-        <p>{order.unitPrice.toLocaleString()}원</p>
+        <p>{finalPrice.toLocaleString()}원</p>
       </div>
       {/* 배송 상태  */}
       <div className="flex gap-3 w-1/6">
-        <OrderStatusBadge status={order.itemStatus} />
+        <OrderStatusBadge status={orderStatus as OrderItemStatus} />
       </div>
     </div>
   );

--- a/src/app/mypage/consumer/orders/components/OrderList.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderList.tsx
@@ -46,6 +46,12 @@ export default function OrderList() {
   if (isLoading || !items) {
     return <MyPageOrdersSkeleton count={6} />;
   }
+  if (items.length === 0)
+    return (
+      <div className="text-red-500 text-center pt-3">
+        <p>주문한 상품이 없습니다.</p>
+      </div>
+    );
 
   return (
     <>

--- a/src/app/mypage/consumer/orders/components/OrderList.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderList.tsx
@@ -7,7 +7,6 @@ import { usePagination } from "@/hooks/usePagination";
 import TabFilter from "../../wishlist/components/tabFilter";
 import OrderStatusFilter from "./OrderStatusFilter";
 import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
-import { useState } from "react";
 import { fetchOrders } from "@/app/mypage/api/fetchOrders";
 import { useQuery } from "@tanstack/react-query";
 import MyPageOrdersSkeleton from "@/app/mypage/components/MypageOrdersSkeleton";
@@ -24,11 +23,11 @@ export default function OrderList() {
     queryFn: fetchOrders,
   });
 
-  const [selectedStatus, setSelectedStatus] = useState("");
   const selectedCategory = searchParams.get("category") ?? "all";
+  const selectedStatus = searchParams.get("status") ?? "all";
 
   const filteredOrders = sortOrders(
-    selectedStatus === ""
+    selectedStatus === "all"
       ? items
       : items.filter((order) => order.order_status === selectedStatus),
     selectedCategory,
@@ -43,6 +42,11 @@ export default function OrderList() {
     router.push(`?category=${slug}`);
   };
 
+  const handleStatusFilter = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("status", value);
+    router.push(`?${params.toString()}`);
+  };
   if (isLoading || !items) {
     return <MyPageOrdersSkeleton count={6} />;
   }
@@ -63,7 +67,7 @@ export default function OrderList() {
         />
         <OrderStatusFilter
           value={selectedStatus}
-          statusChange={setSelectedStatus}
+          statusChange={handleStatusFilter}
         />
       </div>
       <OrderItemHeader />

--- a/src/app/mypage/consumer/orders/components/OrderList.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderList.tsx
@@ -9,17 +9,20 @@ import TabFilter from "../../wishlist/components/tabFilter";
 import OrderStatusFilter from "./OrderStatusFilter";
 import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
 import { useState } from "react";
-
-// 마이페이지에서는 4개 정도 주문 내역 보여주고
-// 주문 내역 클릭 시 전부 다 보여주기
-
-const CATEGORIES = [
-  { id: "", label: "전체" },
-  { id: "writing", label: "필기구" },
-  { id: "paper", label: "노트/메모" },
-];
+import { CATEGORIES } from "../lib/orderTabGroups";
+import { fetchOrders } from "@/app/mypage/api/fetchOrders";
+import { useQuery } from "@tanstack/react-query";
+import MyPageOrdersSkeleton from "@/app/mypage/components/MypageOrdersSkeleton";
+import { OrdersType } from "@/app/lib/Orders";
 
 export default function OrderList() {
+  const { data: items, isLoading } = useQuery<OrdersType[]>({
+    queryKey: ["order"],
+    queryFn: fetchOrders,
+  });
+
+  console.log(items);
+
   const [selectedStatus, setSelectedStatus] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("");
   const filteredOrders =
@@ -29,6 +32,11 @@ export default function OrderList() {
 
   const { currentPage, setCurrentPage, currentItems, totalPages } =
     usePagination(filteredOrders, 5);
+
+  // 로딩 상태일 때 빈 페이지 방지
+  if (isLoading || !items) {
+    return <MyPageOrdersSkeleton count={6} />;
+  }
 
   return (
     <>
@@ -45,11 +53,18 @@ export default function OrderList() {
       </div>
       <OrderItemHeader />
       <ul>
-        {currentItems.map((order) => (
-          <li key={order.id}>
-            <OrderItemCard order={order} />
-          </li>
-        ))}
+        {items.map((orders) =>
+          orders.order_items.map((item) => (
+            <li key={item.id}>
+              <OrderItemCard
+                order={item}
+                createdAt={orders.created_at}
+                finalPrice={orders.final_price}
+                orderStatus={orders.order_status}
+              />
+            </li>
+          )),
+        )}
       </ul>
       <Pagination
         currentPage={currentPage}

--- a/src/app/mypage/consumer/orders/components/OrderList.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderList.tsx
@@ -4,36 +4,45 @@ import OrderItemCard from "./OrderItemCard";
 import OrderItemHeader from "./OrderListHeader";
 import { usePagination } from "@/hooks/usePagination";
 
-import { dummyOrderItems } from "@/data/dummyOrder";
 import TabFilter from "../../wishlist/components/tabFilter";
 import OrderStatusFilter from "./OrderStatusFilter";
 import Pagination from "@/app/mypage/seller/delivery/components/Pagination";
 import { useState } from "react";
-import { CATEGORIES } from "../lib/orderTabGroups";
 import { fetchOrders } from "@/app/mypage/api/fetchOrders";
 import { useQuery } from "@tanstack/react-query";
 import MyPageOrdersSkeleton from "@/app/mypage/components/MypageOrdersSkeleton";
 import { OrdersType } from "@/app/lib/Orders";
+import { useRouter, useSearchParams } from "next/navigation";
+import { sortOrders } from "../lib/sortOrders";
+import { CATEGORIES } from "../lib/orderTabGroups";
 
 export default function OrderList() {
-  const { data: items, isLoading } = useQuery<OrdersType[]>({
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: items = [], isLoading } = useQuery<OrdersType[]>({
     queryKey: ["order"],
     queryFn: fetchOrders,
   });
 
-  console.log(items);
-
   const [selectedStatus, setSelectedStatus] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState("");
-  const filteredOrders =
+  const selectedCategory = searchParams.get("category") ?? "all";
+
+  const filteredOrders = sortOrders(
     selectedStatus === ""
-      ? dummyOrderItems
-      : dummyOrderItems.filter((order) => order.itemStatus === selectedStatus);
+      ? items
+      : items.filter((order) => order.order_status === selectedStatus),
+    selectedCategory,
+  );
 
-  const { currentPage, setCurrentPage, currentItems, totalPages } =
-    usePagination(filteredOrders, 5);
+  const { currentPage, setCurrentPage, totalPages } = usePagination(
+    filteredOrders ?? [],
+    5,
+  );
 
-  // 로딩 상태일 때 빈 페이지 방지
+  const onValueChange = (slug: string) => {
+    router.push(`?category=${slug}`);
+  };
+
   if (isLoading || !items) {
     return <MyPageOrdersSkeleton count={6} />;
   }
@@ -44,7 +53,7 @@ export default function OrderList() {
         <TabFilter
           items={CATEGORIES}
           selectedValue={selectedCategory}
-          onValueChange={setSelectedCategory}
+          onValueChange={onValueChange}
         />
         <OrderStatusFilter
           value={selectedStatus}
@@ -52,25 +61,33 @@ export default function OrderList() {
         />
       </div>
       <OrderItemHeader />
-      <ul>
-        {items.map((orders) =>
-          orders.order_items.map((item) => (
-            <li key={item.id}>
-              <OrderItemCard
-                order={item}
-                createdAt={orders.created_at}
-                finalPrice={orders.final_price}
-                orderStatus={orders.order_status}
-              />
-            </li>
-          )),
-        )}
-      </ul>
-      <Pagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        onPageChange={setCurrentPage}
-      />
+      {filteredOrders?.length === 0 ? (
+        <p className="text-red-500 text-center text-xl mt-5">
+          해당 주문 상태가 존재하지 않습니다.
+        </p>
+      ) : (
+        <>
+          <ul>
+            {filteredOrders?.map((orders) =>
+              orders.order_items.map((item) => (
+                <li key={item.id}>
+                  <OrderItemCard
+                    order={item}
+                    createdAt={orders.created_at}
+                    finalPrice={orders.final_price}
+                    orderStatus={orders.order_status}
+                  />
+                </li>
+              )),
+            )}
+          </ul>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/src/app/mypage/consumer/orders/components/OrderStatusBadge.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderStatusBadge.tsx
@@ -1,10 +1,10 @@
 import { statusLabel } from "@/data/statusLabel";
-import { OrderItem } from "@/app/mypage/types/orderItem";
+import { OrderItemStatus } from "../lib/orderItemStatus";
 
 export default function OrderStatusBadge({
   status,
 }: {
-  status: OrderItem["itemStatus"];
+  status: OrderItemStatus;
 }) {
   const config = statusLabel[status];
 

--- a/src/app/mypage/consumer/orders/components/OrderStatusFilter.tsx
+++ b/src/app/mypage/consumer/orders/components/OrderStatusFilter.tsx
@@ -14,7 +14,7 @@ export default function OrderStatusFilter({ value, statusChange }: Props) {
   };
 
   return (
-    <div className="flex flex-col gap-4 px-2 py-5">
+    <div className="flex flex-col gap-4 px-2 py-5 justify-center">
       <div className="flex items-center gap-2">
         <label htmlFor="filter" className="text-sm text-gray-500 font-medium">
           배송 상태:

--- a/src/app/mypage/consumer/orders/lib/orderItemStatus.ts
+++ b/src/app/mypage/consumer/orders/lib/orderItemStatus.ts
@@ -1,0 +1,8 @@
+export const ORDER_ITEM_STATUS = {
+  PENDING: "배송준비중",
+  SHIPPED: "배송중",
+  DELIVERED: "배송완료",
+  CANCELED: "취소됨",
+} as const;
+
+export type OrderItemStatus = keyof typeof ORDER_ITEM_STATUS;

--- a/src/app/mypage/consumer/orders/lib/orderItemStatus.ts
+++ b/src/app/mypage/consumer/orders/lib/orderItemStatus.ts
@@ -3,6 +3,7 @@ export const ORDER_ITEM_STATUS = {
   SHIPPED: "배송중",
   DELIVERED: "배송완료",
   CANCELED: "취소됨",
+  PAID: "결제완료",
 } as const;
 
 export type OrderItemStatus = keyof typeof ORDER_ITEM_STATUS;

--- a/src/app/mypage/consumer/orders/lib/orderTabGroups.ts
+++ b/src/app/mypage/consumer/orders/lib/orderTabGroups.ts
@@ -1,6 +1,8 @@
 export const CATEGORIES = [
-  { id: "", label: "전체" },
+  { id: "all", label: "전체" },
   { id: "latest", label: "주문 날짜순" },
   { id: "high-price", label: "가격 높은순" },
   { id: "low-price", label: "가격 낮은순" },
 ];
+
+export type CategoryId = (typeof CATEGORIES)[number]["id"];

--- a/src/app/mypage/consumer/orders/lib/orderTabGroups.ts
+++ b/src/app/mypage/consumer/orders/lib/orderTabGroups.ts
@@ -1,0 +1,6 @@
+export const CATEGORIES = [
+  { id: "", label: "전체" },
+  { id: "latest", label: "주문 날짜순" },
+  { id: "high-price", label: "가격 높은순" },
+  { id: "low-price", label: "가격 낮은순" },
+];

--- a/src/app/mypage/consumer/orders/lib/sortOrders.ts
+++ b/src/app/mypage/consumer/orders/lib/sortOrders.ts
@@ -1,0 +1,21 @@
+import { OrdersType } from "@/app/lib/Orders";
+import { CategoryId } from "./orderTabGroups";
+
+export const sortOrders = (items: OrdersType[], sort: CategoryId) => {
+  switch (sort) {
+    case "latest":
+      return items.toSorted(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+
+    case "high-price":
+      return items.toSorted((a, b) => b.final_price - a.final_price);
+
+    case "low-price":
+      return items.toSorted((a, b) => a.final_price - b.final_price);
+
+    default:
+      return items;
+  }
+};

--- a/src/app/mypage/consumer/page.tsx
+++ b/src/app/mypage/consumer/page.tsx
@@ -1,7 +1,4 @@
-import { dummyOrderItems } from "@/data/dummyOrder";
 import OrderList from "./orders/components/OrderList";
-
-const hasProducts = dummyOrderItems.length > 0;
 
 export default function ConsumerPage() {
   return (
@@ -10,13 +7,7 @@ export default function ConsumerPage() {
 
       <section className="flex flex-col gap-4 p-6 w-full bg-white mb-20">
         <h2 className="font-semibold px-5 sr-only">최근 주문 내역</h2>
-        {hasProducts ? (
-          <OrderList />
-        ) : (
-          <div className="text-red-500 text-center pt-3">
-            <p>주문한 상품이 없습니다.</p>
-          </div>
-        )}
+        <OrderList />
       </section>
     </div>
   );

--- a/src/app/mypage/consumer/page.tsx
+++ b/src/app/mypage/consumer/page.tsx
@@ -8,8 +8,6 @@ export default function ConsumerPage() {
     <div>
       <h1 className="sr-only">마이페이지</h1>
 
-      {/* 주문한 상품 없을 시, 없다는 안내 문구, 최근 주문한 4건만 마이 페이지 메인에서 볼 수 있도록 함 */}
-
       <section className="flex flex-col gap-4 p-6 w-full bg-white mb-20">
         <h2 className="font-semibold px-5 sr-only">최근 주문 내역</h2>
         {hasProducts ? (

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsCard.tsx
@@ -2,6 +2,7 @@ import LikeToggleButton from "@/app/mypage/consumer/wishlist/components/LikeTogg
 import Link from "next/link";
 import Image from "next/image";
 import { ProductLikeWithProduct } from "@/app/lib/productLike";
+import { CATEGORY_GROUPS } from "../lib/categoryGroup";
 
 interface Props {
   order: ProductLikeWithProduct;
@@ -9,10 +10,21 @@ interface Props {
 }
 
 export default function WishListItemCard({ order, onRemove }: Props) {
+  const categoryName =
+    order.products.product_categories[0]?.categories.name ?? "";
+
+  const categoryId = CATEGORY_GROUPS.find((group) =>
+    group.categories.includes(categoryName),
+  )?.id;
+
+  const productId = order.products.id;
+
   return (
     <div key={order.id} className="flex flex-col">
       <Link
-        href={`/products/${order.products.product_categories[0]?.categories.name}/${order.id}`}
+        href={{
+          pathname: `/products/${categoryId}/${productId}`,
+        }}
         className="relative flex flex-col transition-transform duration-400 hover:scale-105"
       >
         {order.products.discount_rate > 0 && (

--- a/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
+++ b/src/app/mypage/consumer/wishlist/components/WishListItemsList.tsx
@@ -26,7 +26,6 @@ export default function WishListItemsList() {
     const params = new URLSearchParams(searchParams.toString());
 
     params.set("category", slug);
-    params.set("page", "1"); // 필터 바꾸면 페이지 초기화
 
     router.push(`?${params.toString()}`);
   };
@@ -34,7 +33,6 @@ export default function WishListItemsList() {
   const onChangeSort = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set("sort", value);
-    params.set("page", "1");
 
     router.push(`?${params.toString()}`);
   };

--- a/src/app/mypage/consumer/wishlist/components/tabFilter.tsx
+++ b/src/app/mypage/consumer/wishlist/components/tabFilter.tsx
@@ -4,14 +4,12 @@ interface TabItem {
 }
 
 interface TabFilterProps {
-  items: readonly TabItem[] | TabItem[]; // 수정 가능한 배열 또는 수정 불가능한 배열이 올 수 있음
+  items: readonly TabItem[] | TabItem[];
   selectedValue: string;
   onValueChange: (id: string) => void;
   separator?: string;
 }
 
-// searchParams를 이용하여 탭 항목을 가져오는 형식으로 구현해야 되기때문에,
-// 추후 수정 필요
 export default function TabFilter({
   items,
   selectedValue,

--- a/src/app/mypage/consumer/wishlist/lib/categoryGroup.ts
+++ b/src/app/mypage/consumer/wishlist/lib/categoryGroup.ts
@@ -7,14 +7,14 @@ export const CATEGORY_GROUPS = [
   },
 
   {
-    id: "diary-note",
+    id: "paper",
     label: "노트/다이어리",
 
     categories: ["노트/다이어리", "다이어리", "플래너"],
   },
 
   {
-    id: "desk",
+    id: "office",
     label: "사무/데스크용품",
 
     categories: ["사무/데스크용품", "데스크 수납/정리", "파일/서류보관"],

--- a/src/app/mypage/seller/delivery/components/Pagination.tsx
+++ b/src/app/mypage/seller/delivery/components/Pagination.tsx
@@ -21,7 +21,7 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(1)}
         aria-disabled={currentPage === 1}
-        className={`aria-disabled:cursor-not-allowed `}
+        className={`cursor-pointer aria-disabled:cursor-not-allowed `}
         aria-label="맨 처음 페이지"
       >
         <ChevronsLeft aria-hidden="true" />
@@ -30,7 +30,7 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
         aria-disabled={currentPage === 1}
-        className={`aria-disabled:cursor-not-allowed `}
+        className={`cursor-pointer aria-disabled:cursor-not-allowed `}
         aria-label="이전 페이지"
       >
         <ChevronLeft aria-hidden="true" />
@@ -40,7 +40,7 @@ export default function Pagination({
         <button
           key={i}
           onClick={() => onPageChange(i + 1)}
-          className={` px-2 py-1 ${currentPage === i + 1 ? "text-red-500 font-bold" : ""}`}
+          className={`cursor-pointer px-2 py-1 ${currentPage === i + 1 ? "text-red-500 font-bold" : ""}`}
         >
           {i + 1}
         </button>
@@ -49,7 +49,7 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
         aria-disabled={currentPage === totalPages}
-        className={` aria-disabled:cursor-not-allowed `}
+        className={` cursor-pointer aria-disabled:cursor-not-allowed `}
         aria-label="다음 페이지"
       >
         <ChevronRight aria-hidden="true" />
@@ -58,7 +58,7 @@ export default function Pagination({
       <button
         onClick={() => onPageChange(totalPages)}
         aria-disabled={currentPage === totalPages}
-        className={`aria-disabled:cursor-not-allowed `}
+        className={`cursor-pointer aria-disabled:cursor-not-allowed `}
         aria-label="맨 마지막 페이지"
       >
         <ChevronsRight aria-hidden="true" />

--- a/src/app/mypage/types/coupon_backup.ts
+++ b/src/app/mypage/types/coupon_backup.ts
@@ -1,7 +1,7 @@
-import { Coupon, UserCoupon } from '@/app/lib/coupons';
+import { Coupons, UserCoupons } from "@/app/lib/coupons";
 
-export interface UserCouponCombined extends UserCoupon {
-  coupon_details: Coupon;
+export interface UserCouponCombined extends UserCoupons {
+  coupon_details: Coupons;
 }
 
 export interface CouponItemProps {

--- a/src/data/statusLabel.ts
+++ b/src/data/statusLabel.ts
@@ -1,5 +1,5 @@
 export const statusLabel = {
-  PENDING: { label: "결제대기", color: "text-yellow-500 bg-yellow-100" },
+  PENDING: { label: "배송준비중", color: "text-yellow-500 bg-yellow-100" },
   PAID: { label: "결제 완료", color: "text-green-500 bg-green-100" },
   SHIPPED: { label: "배송 중", color: "text-blue-500 bg-blue-100" },
   DELIVERED: { label: "배송완료", color: "text-gray-700 bg-gray-100" },


### PR DESCRIPTION
### **PR 유형**

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제



### **PR 상세**

#### 1. 코드 작업 중 발생한 오류
Supabase에서 실제 데이터는 처음부터 객체로 왔는데, TypeScript 타입만 배열로 잘못 잡혀서 order.products[0].thumbnail_image 접근 시 에러가 났습니다. fetchOrders에서 .returns<OrdersType[]>()로 실제 응답 구조에 맞게 직접 정의한 타입을 명시적으로 지정해주었습니다. 데이터를 가져올 때 명시적으로 타입을 정해주는 것이 안전한 것 같습니다.. 이 원인 찾느라고 시간이 꽤 소요되서 여러분들을 타입 적고 시작하시길 바랍니다... ㅠㅠㅠ
또한 주문한 상품에 필요한 데이터 타입들을 기존의 lib안에 원본 타입들을 확장한 타입들로 조립하여 사용하였습니다. 

#### 2. tanstackQuery 사용한 데이터 페치
주문한 상품 데이터도 tanstackQuery를 사용하여 데이터를 관리하였습니다. 로딩 처리도 내장되어있는 isLoading 함수를 사용하였습니다. 

#### 3. 탭필터 및 정렬 기능 슈파베이스 연동 및 로직 구현
기존에 더미데이터를 연결한 후 탭필터는 주문 날짜 순, 가격 높은/낮은 순의 필터를 클릭 시 데이터들을 해당 탭에 맞게 정렬해주고 또한 각 필터의 id를 받아서 쿼리 스트링으로 설정하였습니다. 배송 상태 정렬 기능 또한 해당 배송 상태에 따라 불러온 데이터의 배송 상태과 일치하는 주문 상품들이 다시 정렬되도록하는 기능을 추가하였습니다. 배송 상태 정렬 기능 또한 쿼리 스트링 설정하였습니다. 해당 배송 상태와 일치하는 주문 상품이 없을 경우 "해당 주문 상태가 존재하지 않습니다." 라는 안내 문구가 표시가 되도록 조건부 렌더링을 추가했습니다. 주문 목록 페이지에 연결했던 더미데이터는 판매자 페이지까지 완성 한 후 모두 제거하도록 하겠습니다. 

#### 4. 주문한 상품의 이미지 클릭 시 해당 상품 상세 페이지로 이동 연결
주문한 상품 목록에서 상품 클릭 시 상품의 상세 페이지로 이동하도록 쿼리스트링을 상품 상세 페이지와 맞춰서 만들었습니다.

#### 5. 빌드 과정에 오타 수정
빌드를 하였을 때 근영님의 쿠폰 백업 타입 파일 내의 오타가 있다는 오류를 발견하고 수정을 하였습니다. 


#### 6. 로컬에서 빌드 및 배포 테스트 완료, 이상 없음

<img width="2124" height="1656" alt="image" src="https://github.com/user-attachments/assets/36da1fa2-8b19-4f9b-b697-2e07c0833098" />


<img width="2124" height="1317" alt="image" src="https://github.com/user-attachments/assets/346fed94-2028-4dad-9e1e-42046919d3c0" />


### **이슈번호 # 131 **
