### PR TITLE
Feat 157 배송 관리 버튼 배송 상태 변경 기능 추가와 페이지네이션 이슈

### DIFF
--- a/src/app/mypage/api/updateDeliveryStatus.ts
+++ b/src/app/mypage/api/updateDeliveryStatus.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@/utils/supabase/client'
+import { OrderItem } from '../types/orderItem'
+
+export const updateDeliveryStatus = async (
+  orderItemId: string,
+  status: OrderItem['item_status'],
+  orderId: string,
+) => {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('order_items')
+    .update({
+      item_status: status,
+    })
+    .eq('id', orderItemId)
+
+  if (error) throw error
+
+  const { error: orderError } = await supabase
+    .from('orders')
+    .update({ order_status: status })
+    .eq('id', orderId)
+
+  if (orderError) throw orderError
+}

--- a/src/app/mypage/seller/delivery/components/DeliveryProductCard.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryProductCard.tsx
@@ -1,13 +1,10 @@
-'use client'
 import OrderStatusBadge from '@/app/mypage/consumer/orders/components/OrderStatusBadge'
 import { OrderItem } from '@/app/mypage/types/orderItem'
 import DeliverStatusButton from './DeliveryStatusButton'
 import { TotalPriceFormat } from '@/utils/intl'
-// import { useState } from 'react'
 
 export default function DeliveryProductCard({ order }: { order: OrderItem }) {
   const emailPrefix = order.email?.split('@')[0]
-  // const [openId, setOpenId] = useState<string | null>(null)
 
   return (
     <div className="mb-2 flex gap-5 border-b border-gray-300 p-4 font-semibold">

--- a/src/app/mypage/seller/delivery/components/DeliveryProductCard.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryProductCard.tsx
@@ -39,7 +39,11 @@ export default function DeliveryProductCard({ order }: { order: OrderItem }) {
 
       <div className="flex w-3/10 shrink-0 gap-3">
         <OrderStatusBadge status={order.item_status} />
-        <DeliverStatusButton />
+        <DeliverStatusButton
+          orderItemId={order.id}
+          currentStatus={order.item_status}
+          orderId={order.orders.id}
+        />
       </div>
     </div>
   )

--- a/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
@@ -8,6 +8,7 @@ import useDeliveryOrders from '@/hooks/useDeliveryOrders'
 import { useState } from 'react'
 import MypageDeliverySkeleton from '@/app/mypage/components/MypageDeliverSkeleton'
 import { useDeliveryQuery } from '../hooks/useDeliveryQuery'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 const CATEGORIES = [
   { id: 'All', label: '전체', sort: 'All' },
@@ -17,21 +18,27 @@ const CATEGORIES = [
 ] as const
 
 export default function DeliveryProductList() {
-  // 1. 페이지네이션 및 데이터 페칭
+  // 1. 페이지네이션, 데이터 페칭, 서치파람스
   const [currentPage, setCurrentPage] = useState(1)
-
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const category = searchParams.get('category') ?? 'All'
   const { data, isLoading } = useDeliveryQuery(currentPage, 5)
   const items = data?.items ?? []
   const count = data?.count ?? 0
   const totalPages = Math.ceil(count / 5)
 
-  // 2. 정렬 + 데이터는 hook에서 처리
-  const { sortType, handleTabChange, sortedOrders } = useDeliveryOrders(items)
+  // 2. 정렬 + 데이터는 커스텀 hook에서 처리
+  const { sortType, handleTabChange, sortedOrders } = useDeliveryOrders(
+    items,
+    category,
+  )
   const currentItems = sortedOrders
 
   const handleTabChangeWithReset = (id: string) => {
     handleTabChange(id, CATEGORIES)
     setCurrentPage(1)
+    router.push(`?category=${id}`)
   }
 
   if (isLoading || !items) {

--- a/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryProductList.tsx
@@ -1,33 +1,33 @@
 'use client'
 
-import DeliveryProductCard from "./DeliveryProductCard";
-import Pagination from "./Pagination";
-import TabFilter from "@/app/mypage/consumer/wishlist/components/tabFilter";
-import DeliveryProductHeader from "./DeliveryProductHeader";
-import useDeliveryOrders from "@/hooks/useDeliveryOrders";
-import { useState } from "react";
-import MypageDeliverySkeleton from "@/app/mypage/components/MypageDeliverSkeleton";
-import { useDeliveryQuery } from "../hooks/useDeliveryQuery";
+import DeliveryProductCard from './DeliveryProductCard'
+import Pagination from './Pagination'
+import TabFilter from '@/app/mypage/consumer/wishlist/components/tabFilter'
+import DeliveryProductHeader from './DeliveryProductHeader'
+import useDeliveryOrders from '@/hooks/useDeliveryOrders'
+import { useState } from 'react'
+import MypageDeliverySkeleton from '@/app/mypage/components/MypageDeliverSkeleton'
+import { useDeliveryQuery } from '../hooks/useDeliveryQuery'
 
 const CATEGORIES = [
   { id: 'All', label: '전체', sort: 'All' },
-  { id: 'latest', label: '주문 날짜 순', sort: 'latest' },
+  { id: 'latest', label: '주문 최신순', sort: 'latest' },
   { id: 'highPrice', label: '금액 높은 순', sort: 'highPrice' },
   { id: 'lowPrice', label: '금액 낮은 순', sort: 'lowPrice' },
 ] as const
 
 export default function DeliveryProductList() {
   // 1. 페이지네이션 및 데이터 페칭
-  const [currentPage, setCurrentPage] = useState(1);
- 
-  const { data, isLoading } = useDeliveryQuery(currentPage, 5);
-  const items = data?.items ?? [];
-  const count = data?.count ?? 0;
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const { data, isLoading } = useDeliveryQuery(currentPage, 5)
+  const items = data?.items ?? []
+  const count = data?.count ?? 0
   const totalPages = Math.ceil(count / 5)
 
   // 2. 정렬 + 데이터는 hook에서 처리
-  const { sortType, handleTabChange, sortedOrders } = useDeliveryOrders(items);
-  const currentItems = sortedOrders;
+  const { sortType, handleTabChange, sortedOrders } = useDeliveryOrders(items)
+  const currentItems = sortedOrders
 
   const handleTabChangeWithReset = (id: string) => {
     handleTabChange(id, CATEGORIES)
@@ -35,16 +35,16 @@ export default function DeliveryProductList() {
   }
 
   if (isLoading || !items) {
-    return <MypageDeliverySkeleton count={5} />;
+    return <MypageDeliverySkeleton count={5} />
   }
 
-  const hasItems = currentItems.length > 0;
+  const hasItems = currentItems.length > 0
 
   return (
     <div className="flex flex-col">
       {hasItems ? (
         <>
-          <div className="flex  flex-col ">
+          <div className="flex flex-col px-5">
             <TabFilter
               items={CATEGORIES}
               selectedValue={sortType}
@@ -68,8 +68,8 @@ export default function DeliveryProductList() {
           />
         </>
       ) : (
-        <div className="text-red-500 text-center pt-3">
-          <p>주문된 상품이 없습니다.</p>{" "}
+        <div className="pt-3 text-center text-red-500">
+          <p>주문된 상품이 없습니다.</p>{' '}
         </div>
       )}
     </div>

--- a/src/app/mypage/seller/delivery/components/DeliveryStatusButton.tsx
+++ b/src/app/mypage/seller/delivery/components/DeliveryStatusButton.tsx
@@ -1,9 +1,73 @@
-export default function DeliverStatusButton() {
-  //  추후에 관리 버튼을 누르면 배송 준비중 | 배송 중 | 배송 완료 같은 상태를 제어할 수 있는 기능 구현
-  // 이 기능은 소비자 마이페이지 나의 주문 내역의 배송 상태와 연결이 되어야 됨
+'use client'
+
+import { OrderItem } from '@/app/mypage/types/orderItem'
+import { useState } from 'react'
+import { useDeliveryStatus } from '../hooks/useDeliveryStatus'
+import { statusLabel } from '@/data/statusLabel'
+
+const STATUS_OPTIONS: OrderItem['item_status'][] = [
+  'PENDING',
+  'PAID',
+  'SHIPPED',
+  'DELIVERED',
+  'CANCELED',
+]
+
+type Props = {
+  orderItemId: string
+  currentStatus: OrderItem['item_status']
+  orderId: string
+}
+
+export default function DeliverStatusButton({
+  orderItemId,
+  currentStatus,
+  orderId,
+}: Props) {
+  const [isClose, setIsOpen] = useState(false)
+  const { mutate } = useDeliveryStatus()
+  const handleStatusChange = (status: OrderItem['item_status']) => {
+    mutate({ orderItemId, status, orderId })
+    setIsOpen(false)
+  }
+
+  const filteredStatus = STATUS_OPTIONS.filter(
+    (status) => status !== currentStatus,
+  )
+
   return (
-    <button className="rounded-md border border-gray-300 px-3 py-1 font-semibold hover:bg-gray-300 hover:text-white">
-      관리
-    </button>
+    <div className="flex flex-col pr-3">
+      <button
+        onClick={() => setIsOpen(!isClose)}
+        aria-disabled={currentStatus === 'DELIVERED'}
+        className={`${currentStatus === 'DELIVERED' ? 'cursor-not-allowed opacity-50' : 'hover:bg-gray-400 hover:text-white'} mb-2 shrink-0 rounded-md border border-gray-300 px-3 py-1 font-semibold hover:bg-gray-300 hover:text-white`}
+      >
+        관리
+      </button>
+      {currentStatus !== 'DELIVERED' && isClose && (
+        <ul>
+          {filteredStatus.map((status) => {
+            const config = statusLabel[status]
+            return (
+              <li key={status} className="flex flex-col gap-3">
+                <button
+                  type="button"
+                  className={`${config.color} mb-3 cursor-pointer rounded-2xl p-2 text-center transition-all duration-200 hover:scale-[1.02]`}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.boxShadow = `0 0 14px ${config.glow}`
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.boxShadow = 'none'
+                  }}
+                  onClick={() => handleStatusChange(status)}
+                >
+                  {config.label}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
   )
 }

--- a/src/app/mypage/seller/delivery/hooks/useDeliveryQuery.ts
+++ b/src/app/mypage/seller/delivery/hooks/useDeliveryQuery.ts
@@ -1,9 +1,9 @@
-import { fetchDelivery } from "@/app/mypage/api/fetchDelivery";
-import { useQuery } from "@tanstack/react-query";
+import { fetchDelivery } from '@/app/mypage/api/fetchDelivery'
+import { useQuery } from '@tanstack/react-query'
 
 export const useDeliveryQuery = (page: number, limit: number) => {
   return useQuery({
-    queryKey: ["delivery"],
+    queryKey: ['delivery', page, limit],
     queryFn: () => fetchDelivery(page, limit),
-  });
-};
+  })
+}

--- a/src/app/mypage/seller/delivery/hooks/useDeliveryStatus.ts
+++ b/src/app/mypage/seller/delivery/hooks/useDeliveryStatus.ts
@@ -1,0 +1,28 @@
+// 배송 상태 변경해주는 훅
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { OrderItem } from '@/app/mypage/types/orderItem'
+import { updateDeliveryStatus } from '@/app/mypage/api/updateDeliveryStatus'
+
+export const useDeliveryStatus = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      orderItemId,
+      status,
+      orderId,
+    }: {
+      orderItemId: string
+      status: OrderItem['item_status']
+      orderId: string
+    }) => updateDeliveryStatus(orderItemId, status, orderId),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['delivery'],
+        refetchType: 'all',
+      })
+    },
+  })
+}

--- a/src/app/mypage/seller/register/actions/registerProduct.ts
+++ b/src/app/mypage/seller/register/actions/registerProduct.ts
@@ -110,8 +110,8 @@ async function processRegister(formData: FormData): Promise<FormState> {
     .single()
 
   // 실제 Supabase Storage에 업로드
-  const imageFile = image as File;
-  const ext = imageFile.name.split(".").pop();
+  const imageFile = image as File
+  const ext = imageFile.name.split('.').pop()
 
   // 고유한 영문 파일명 생성
   const fileName = `${Date.now()}.${ext}`
@@ -131,7 +131,7 @@ async function processRegister(formData: FormData): Promise<FormState> {
     .from('public-assets')
     .getPublicUrl(`products/${fileName}`)
 
-  const finalDescription = { description };
+  const finalDescription = `<img src="https://xgiayrmzgokjzwwzivzi.supabase.co/storage/v1/object/public/public-assets/products/product2.jpg" alt="상세이미지"/><br/>${description}`
 
   const { data, error } = await supabase
     .from('products')

--- a/src/app/mypage/seller/register/components/RegisterProduct.tsx
+++ b/src/app/mypage/seller/register/components/RegisterProduct.tsx
@@ -67,10 +67,10 @@ export default function RegisterProductForm() {
   }
 
   const handleSubmit = (e: React.FormEvent) => {
-    const newErrors = validateAll();
+    const newErrors = validateAll()
 
     if (!imgForm.preview) {
-      newErrors.productImage = "상품 이미지를 업로드해주세요.";
+      newErrors.productImage = '상품 이미지를 업로드해주세요.'
     }
 
     setClientErrors(newErrors)
@@ -84,8 +84,7 @@ export default function RegisterProductForm() {
 
     // 하나라도 폼 양식이 작성되어있지 않은 경우에, 제출을 할 수 없음
     if (Object.keys(newErrors).length > 0) {
-      imgForm.resetImg();
-      e.preventDefault();
+      e.preventDefault()
     }
   }
 
@@ -130,7 +129,10 @@ export default function RegisterProductForm() {
           key={imgForm.imgKey}
           fileName={imgForm.fileName}
           preview={imgForm.preview}
-          onChangeImg={imgForm.handleChangeImg}
+          onChangeImg={(e) => {
+            imgForm.handleChangeImg(e)
+            setClientErrors((prev) => ({ ...prev, productImage: undefined }))
+          }}
           error={clientErrors.productImage || serverErrors?.productImage}
         />
         <ProductName

--- a/src/data/statusLabel.ts
+++ b/src/data/statusLabel.ts
@@ -1,7 +1,27 @@
 export const statusLabel = {
-  PENDING: { label: "배송준비중", color: "text-yellow-500 bg-yellow-100" },
-  PAID: { label: "결제 완료", color: "text-pink-500 bg-pink-100" },
-  SHIPPED: { label: "배송 중", color: "text-blue-500 bg-blue-100" },
-  DELIVERED: { label: "배송완료", color: "text-green-700 bg-green-100" },
-  CANCELED: { label: "취소됨", color: "text-red-500 bg-red-100" },
-};
+  PENDING: {
+    label: '배송준비중',
+    color: 'text-yellow-500 bg-yellow-100',
+    glow: 'rgba(234,179,8,0.35)',
+  },
+  PAID: {
+    label: '결제 완료',
+    color: 'text-pink-500 bg-pink-100',
+    glow: 'rgba(236,72,153,0.35)',
+  },
+  SHIPPED: {
+    label: '배송 중',
+    color: 'text-blue-500 bg-blue-100',
+    glow: 'rgba(59,130,246,0.35)',
+  },
+  DELIVERED: {
+    label: '배송완료',
+    color: 'text-green-700 bg-green-100',
+    glow: 'rgba(34,197,94,0.35)',
+  },
+  CANCELED: {
+    label: '취소됨',
+    color: 'text-red-500 bg-red-100',
+    glow: 'rgba(239,68,68,0.35)',
+  },
+}

--- a/src/hooks/useDeliveryOrders.ts
+++ b/src/hooks/useDeliveryOrders.ts
@@ -2,10 +2,7 @@ import { OrderItem } from '@/app/mypage/types/orderItem'
 import { useMemo, useState } from 'react'
 
 // 탭에서 선택되는 정렬 기준을 정의한 타입 지정
-type SortType = 'All' | 'latest' | 'oldest' | 'highPrice' | 'lowPrice'
-
-// 배송 관리에 포함할 주문 상태 타입 지정
-// type SalesStatus = "PAID" | "SHIPPED" | "DELIVERED"
+type SortType = 'All' | 'latest' | 'highPrice' | 'lowPrice'
 
 // 탭 UI 하나를 표현하는 데이터 구조
 interface Category {
@@ -14,10 +11,19 @@ interface Category {
   sort: SortType
 }
 
-export default function useDeliveryOrders(items: OrderItem[]) {
-  const [sortType, setSortType] = useState<SortType>('All')
+export default function useDeliveryOrders(
+  items: OrderItem[],
+  initialSort: string,
+) {
+  const safeSortType: SortType =
+    initialSort === 'latest' ||
+    initialSort === 'highPrice' ||
+    initialSort === 'lowPrice'
+      ? initialSort
+      : 'All'
 
-  // 1. 데이터 추출
+  const [sortType, setSortType] = useState<SortType>(safeSortType)
+
   // 조건에 맞는 데이터 배열 새로 만들기
   const myOrders = useMemo(() => {
     // items가 변경될 때만 필터링 + 변환 다시 실행
@@ -28,7 +34,6 @@ export default function useDeliveryOrders(items: OrderItem[]) {
     }))
   }, [items])
 
-  // 2. 데이터 가공
   // 해당 탭에 따라서 데이터 정렬해주는 핸들러 함수 만들기
   const handleTabChange = (id: string, categories: readonly Category[]) => {
     // 카테고리 아이디와 일치하는 탭 아이디 찾기
@@ -40,7 +45,13 @@ export default function useDeliveryOrders(items: OrderItem[]) {
     }
   }
 
-  //3. 데이터 정렬
+  function getFinalPrice(item: OrderItem) {
+    const price = Number(item.unit_price)
+    const discount = Number(item.products?.discount_rate ?? 0)
+
+    return price * (1 - discount / 100)
+  }
+
   // 탭 종류에 따라 해당 데이터 키값을 반환해주는 함수
   // sortType에 따라 myOrders 정렬해서 반환
   const sortedOrders = useMemo(() => {
@@ -52,19 +63,10 @@ export default function useDeliveryOrders(items: OrderItem[]) {
         case 'latest':
           return b.orderTime - a.orderTime
 
-        case 'oldest':
-          return a.orderTime - b.orderTime
-
         case 'highPrice':
-          return (
-            b.unit_price * (1 - b.products.discount_rate / 100) -
-            a.unit_price * (1 - a.products.discount_rate / 100)
-          )
+          return getFinalPrice(b) - getFinalPrice(a)
         case 'lowPrice':
-          return (
-            a.unit_price * (1 - a.products.discount_rate / 100) -
-            b.unit_price * (1 - b.products.discount_rate / 100)
-          )
+          return getFinalPrice(a) - getFinalPrice(b)
 
         default:
           return 0

--- a/src/hooks/useDeliveryOrders.ts
+++ b/src/hooks/useDeliveryOrders.ts
@@ -1,5 +1,5 @@
-import { OrderItem } from "@/app/mypage/types/orderItem";
-import { useMemo, useState } from "react";
+import { OrderItem } from '@/app/mypage/types/orderItem'
+import { useMemo, useState } from 'react'
 
 // 탭에서 선택되는 정렬 기준을 정의한 타입 지정
 type SortType = 'All' | 'latest' | 'oldest' | 'highPrice' | 'lowPrice'
@@ -15,7 +15,7 @@ interface Category {
 }
 
 export default function useDeliveryOrders(items: OrderItem[]) {
-  const [sortType, setSortType] = useState<SortType>("All");
+  const [sortType, setSortType] = useState<SortType>('All')
 
   // 1. 데이터 추출
   // 조건에 맞는 데이터 배열 새로 만들기
@@ -25,8 +25,8 @@ export default function useDeliveryOrders(items: OrderItem[]) {
     return items.map((item) => ({
       ...item,
       orderTime: new Date(item.orders.created_at).getTime(),
-    }));
-  }, [items]);
+    }))
+  }, [items])
 
   // 2. 데이터 가공
   // 해당 탭에 따라서 데이터 정렬해주는 핸들러 함수 만들기
@@ -59,12 +59,12 @@ export default function useDeliveryOrders(items: OrderItem[]) {
           return (
             b.unit_price * (1 - b.products.discount_rate / 100) -
             a.unit_price * (1 - a.products.discount_rate / 100)
-          );
-        case "lowPrice":
+          )
+        case 'lowPrice':
           return (
             a.unit_price * (1 - a.products.discount_rate / 100) -
             b.unit_price * (1 - b.products.discount_rate / 100)
-          );
+          )
 
         default:
           return 0


### PR DESCRIPTION
### **PR 유형**

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**

- 배송 관리 버튼 UI 추가
- 배송 상태 변경 기능 구현 (PENDING / PAID / SHIPPED / DELIVERED / CANCELED)
- 배송 상태 변경 시 orders/order_item들의 order_status,item_status 변경 되는 거 확인 완료
- 현재 배송 상태를 제외한 나머지 배송 상태 항목들로 변경이 가능하게 기능 추가
- 배송 완료 시에 배송 상태 관리 버튼 접근 방지 (aria-disabled) 사용
- 사용자 아이디를 이메일의 @ 앞의 글자들만 가져와서 표시
- 주문 목록 페이지네이션 적용
- 탭 URL 기반 카테고리 상태 관리 적용
- 탭 항목 클릭 시 해당 기준에 정렬이 된 상태로 1페이지부터 시작

### **PR 상세**

#### 1, 배송 상태 변경 후 데이터 동기화 문제

배송 상태를 변경했을 때:
order_items 상태는 정상 업데이트됨
하지만 orders.order_status와 화면 데이터가 즉시 반영되지 않는 문제 발생
→order_items 상태 업데이트와 orders.order_status 함께 업데이트 처리,  Tanstack Query invalidateQueries의 refetchType를 사용하여 상태변경이 있을 시 queryKey에 연결된 모든 캐시 데이터를 한 번에 갱신하도록 처리데이터 재조회하는 방식으로 로직 추가


#### 2. 서버 기반 페이지네이션 이슈
리펙토링한 페이지네이션의 작동 원리는 서버에서 페이지 단위로 데이터를 잘라서 가져오는 구조
프론트에서 정렬을 처리하면서 일부 데이터가 전체 기준 정렬과 다르게 보이는 문제 발생
예: highPrice에서 0원 상품이 중간에 섞이는 현상

문제 분석 결과 페이지네이션이 먼저 적용된 상태에서 정렬 수행됨, 전체 데이터 기준이 아닌 “페이지 내부 데이터 기준 정렬”이 됨.

- 해결 방향
성능을 고려하여 전체 데이터 fetch는 제외하고:
서버: 페이지네이션 유지 (성능 최적화)
클라이언트: 정렬 처리 (UX 즉시 반영)
-> 이렇게 나눠서 처리하게됨. 각 페이지를 기준으로 페이지의 해당하는 아이템 기준으로 정렬이 됨. 

- 해결 방법 채택 이유
전체 데이터 fetch는 성능 부담 큼
Supabase join + 계산 정렬을 서버에서 처리하기 어려움 (현재 서버를 불러오는 방법과는 완전히 생소한 로직이여서 이 부분은 구현하기에 난이도가 있음)
UI 반응 속도 확보 필요

<img width="2174" height="2258" alt="image" src="https://github.com/user-attachments/assets/7ee29261-66bd-4046-aadf-a45322502d05" />


<img width="1081" height="1294" alt="image" src="https://github.com/user-attachments/assets/c90c8f50-c865-4568-85cf-6c46214379f0" />


### **이슈번호 #157 **
