### PR TITLE
Feat 177 products pages caching

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   /* config options here */
-  // cacheComponents: true,
+  cacheComponents: true,
   images: {
     remotePatterns: [
       {

--- a/src/actions/cartAction.ts
+++ b/src/actions/cartAction.ts
@@ -3,7 +3,7 @@
 import { createClient } from '@/utils/supabase/server'
 import { z } from 'zod'
 import { getAuthUserInfo } from './getUser'
-import { revalidatePath } from 'next/cache'
+import { cacheLife, cacheTag, revalidatePath } from 'next/cache'
 import { SelectedOption } from '@/app/lib/cart.types'
 
 type AddCartParams = {
@@ -41,15 +41,16 @@ const updateCartQuantitySchema = z.object({
 
 // 삭제를 위한 Zod 스키마 추가
 const deleteCartItemSchema = z.object({
-  cartItemId: z.string({ message: "삭제할 장바구니 아이템 ID가 필요합니다." }),
+  cartItemId: z.string({ message: '삭제할 장바구니 아이템 ID가 필요합니다.' }),
 })
 
 export type UpdateCartQuantity = z.infer<typeof updateCartQuantitySchema>
 export type DeleteCartItem = z.infer<typeof deleteCartItemSchema> // 타입 추출
 
 export async function getCarts() {
-  // 'use cache'
-  // cacheTag('cart', 'max')
+  'use cache'
+  cacheTag('cart', 'max')
+  cacheLife('minutes')
 
   const auth = await getAuthUserInfo()
 
@@ -175,6 +176,8 @@ export async function addCartItem({
   if (error) {
     throw new Error(error.message)
   }
+
+  revalidatePath('/cart')
 }
 
 // 장바구니 아이템 삭제 Server Action 추가
@@ -188,14 +191,15 @@ export async function deleteCartItem(input: DeleteCartItem) {
   // Zod를 통한 입력 파라미터 검증
   const parsedInput = deleteCartItemSchema.safeParse(input)
   if (!parsedInput.success) {
-    const errorMessage = parsedInput.error.issues[0]?.message || '잘못된 입력값입니다.'
+    const errorMessage =
+      parsedInput.error.issues[0]?.message || '잘못된 입력값입니다.'
     return { success: false, message: errorMessage }
   }
 
   const { cartItemId } = parsedInput.data
 
   const supabase = await createClient()
-  
+
   const { error } = await supabase
     .from('cart_items')
     .delete()
@@ -206,8 +210,8 @@ export async function deleteCartItem(input: DeleteCartItem) {
     console.error(error.message)
     return { success: false, message: '상품 삭제에 실패했습니다.' }
   }
-  
+
   revalidatePath('/cart')
-  
+
   return { success: true, message: '상품이 장바구니에서 삭제되었습니다.' }
 }

--- a/src/api/productDetailApi.ts
+++ b/src/api/productDetailApi.ts
@@ -1,34 +1,74 @@
 import { Products } from '@/app/lib/products.types'
 import { Store } from '@/app/lib/stores.types'
-import { createClient } from '@/utils/supabase/server'
+import { createStaticClient } from '@/utils/supabase/static'
+import { cacheLife, cacheTag } from 'next/cache'
 import { notFound } from 'next/navigation'
 
-export const getProductDetail = async (id: string): Promise<Products> => {
-  const supabase = await createClient()
+interface ProductProps {
+  id: string
+  mainCategory: string
+}
+
+export const getProductDetail = async ({
+  id,
+  mainCategory,
+}: ProductProps): Promise<Products> => {
+  'use cache'
+
+  cacheLife('hours')
+
+  cacheTag('products')
+  cacheTag(`product-${id}`)
+  cacheTag(`products-${mainCategory}`)
+
+  const supabase = createStaticClient()
 
   const { data, error } = await supabase
     .from('products')
     .select('*')
     .eq('id', id)
-    .single()
+    .maybeSingle()
 
   if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data) {
     notFound()
   }
 
-  return data
+  return data as Products
 }
-export const getStoreDetailInfo = async (id: string): Promise<Store> => {
-  const supabase = await createClient()
+
+interface StoreProps {
+  id: string
+}
+
+export const getStoreDetailInfo = async ({
+  id,
+}: StoreProps): Promise<Store> => {
+  'use cache'
+
+  cacheLife('days')
+
+  cacheTag('stores')
+  cacheTag(`store-${id}`)
+
+  const supabase = createStaticClient()
+
   const { data, error } = await supabase
     .from('stores')
     .select('*')
     .eq('id', id)
-    .single()
+    .maybeSingle()
 
   if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data) {
     notFound()
   }
 
-  return data
+  return data as Store
 }

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -1,6 +1,14 @@
 import { Products } from '@/app/lib/products.types'
-import { createClient } from '@/utils/supabase/server'
+import { cacheLife, cacheTag } from 'next/cache'
+
+import {
+  getMainCategoryName,
+  getSubCategoryName,
+  isMainCategory,
+} from '@/app/(shop)/products/[mainCategory]/lib/category'
+
 import { notFound } from 'next/navigation'
+import { createStaticClient } from '@/utils/supabase/static'
 
 type ProductsResponse = {
   products: Products[]
@@ -15,47 +23,41 @@ type GetProductsParams = {
   pageSize: number
 }
 
-const MAIN_CATEGORY_MAP: Record<string, string> = {
-  writing: '필기구',
-  paper: '노트/다이어리',
-  deco: '데코/다꾸',
-  office: '사무/데스크용품',
-}
-
-const SUB_CATEGORY_MAP: Record<string, string> = {
-  ballpen: '볼펜',
-  fountainpen: '만년필',
-  sharp: '샤프',
-  diary: '다이어리',
-  planner: '플래너',
-  'desk-organizer': '데스크 수납/정리',
-  'file-storage': '파일/서류보관',
-  'masking-tape': '마스킹테이프',
-  sticker: '스티커',
-}
-
-const getDiscountPrice = (price: number, discount: number) => {
-  return price * (1 - discount / 100)
-}
-
 export const getProductsCategory = async (
   params: GetProductsParams,
 ): Promise<ProductsResponse> => {
-  const supabase = await createClient()
+  'use cache'
 
-  const mainCategoryName = MAIN_CATEGORY_MAP[params.mainCategory]
-    ? MAIN_CATEGORY_MAP[params.mainCategory]
-    : notFound()
-  const subCategoryName = params.category
-    ? SUB_CATEGORY_MAP[params.category]
-    : ''
+  cacheLife('hours')
+
+  cacheTag('products')
+  cacheTag(`products-${params.mainCategory}`)
+
+  const supabase = await createStaticClient()
+
+  // 메인 카테고리 검증
+  if (!isMainCategory(params.mainCategory)) {
+    notFound()
+  }
+
+  const mainCategoryKey = params.mainCategory
+
+  const mainCategoryName = getMainCategoryName(mainCategoryKey)
+
+  const subCategoryName = getSubCategoryName(mainCategoryKey, params.category)
+
+  // 메인 카테고리 조회
   const { data: mainCategory, error: mainCategoryError } = await supabase
     .from('categories')
     .select('id, name, parent_id')
     .eq('name', mainCategoryName)
     .maybeSingle()
 
-  if (mainCategoryError || !mainCategory) {
+  if (mainCategoryError) {
+    throw new Error(mainCategoryError.message)
+  }
+
+  if (!mainCategory) {
     return {
       products: [],
       totalCount: 0,
@@ -64,23 +66,31 @@ export const getProductsCategory = async (
 
   let categoryIds: string[] = []
 
+  // 서브 카테고리 존재
   if (subCategoryName) {
-    const { data: subCategory, error: subCategoryError } = await supabase
+    const { data: subCategoryData, error: subCategoryError } = await supabase
       .from('categories')
       .select('id, name, parent_id')
       .eq('name', subCategoryName)
       .eq('parent_id', mainCategory.id)
       .maybeSingle()
 
-    if (subCategoryError || !subCategory) {
+    if (subCategoryError) {
+      throw new Error(subCategoryError.message)
+    }
+
+    if (!subCategoryData) {
       return {
         products: [],
         totalCount: 0,
       }
     }
 
-    categoryIds = [subCategory.id]
-  } else {
+    categoryIds = [subCategoryData.id]
+  }
+
+  // 전체 카테고리
+  else {
     const { data: childCategories, error: childError } = await supabase
       .from('categories')
       .select('id')
@@ -96,6 +106,7 @@ export const getProductsCategory = async (
     ]
   }
 
+  // 상품 ID 조회
   const { data: productCategoryData, error: productCategoryError } =
     await supabase
       .from('product_categories')
@@ -120,27 +131,48 @@ export const getProductsCategory = async (
     .select('*', { count: 'exact' })
     .in('id', productIds)
 
+  // 정렬
   switch (params.sort) {
     case 'latest':
-      query = query.order('created_at', { ascending: false })
+      query = query.order('created_at', {
+        ascending: false,
+      })
       break
 
     case 'lowPrice':
-      query = query.order('price', { ascending: true })
+      query = query.order('price', {
+        ascending: true,
+      })
       break
 
     case 'highPrice':
-      query = query.order('price', { ascending: false })
+      query = query.order('price', {
+        ascending: false,
+      })
       break
+
     case 'popular':
       query = query
-        .order('average_grade', { ascending: false, nullsFirst: false })
-        .order('created_at', { ascending: false })
+        .order('average_grade', {
+          ascending: false,
+          nullsFirst: false,
+        })
+        .order('created_at', {
+          ascending: false,
+        })
       break
+
+    default:
+      query = query.order('created_at', {
+        ascending: false,
+      })
   }
 
-  const currentPage = Number(params.page) || 1
+  // 페이지네이션
+  const currentPage = params.page && params.page > 0 ? params.page : 1
+
   const from = (currentPage - 1) * params.pageSize
+
   const to = from + params.pageSize - 1
 
   const { data, error, count } = await query.range(from, to)
@@ -149,19 +181,8 @@ export const getProductsCategory = async (
     throw new Error(error.message)
   }
 
-  let products = (data as Products[]) ?? []
-
-  if (params.sort === 'lowPrice' || params.sort === 'highPrice') {
-    products = [...products].sort((a, b) => {
-      const aPrice = getDiscountPrice(a.price, a.discount_rate)
-      const bPrice = getDiscountPrice(b.price, b.discount_rate)
-
-      return params.sort === 'lowPrice' ? aPrice - bPrice : bPrice - aPrice
-    })
-  }
-
   return {
-    products,
+    products: (data as Products[]) ?? [],
     totalCount: count ?? 0,
   }
 }

--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -1,8 +1,17 @@
 import { Reviews } from '@/app/lib/reviews.types'
-import { createClient } from '@/utils/supabase/server'
+import { createStaticClient } from '@/utils/supabase/static'
+import { cacheLife, cacheTag } from 'next/cache'
 
 export async function getProductReviews(productId: string): Promise<Reviews[]> {
-  const supabase = await createClient()
+  'use cache'
+
+  cacheLife('minutes')
+
+  cacheTag('reviews')
+  cacheTag(`reviews-${productId}`)
+  cacheTag(`product-${productId}`)
+
+  const supabase = createStaticClient()
 
   const { data, error } = await supabase
     .from('reviews')
@@ -30,13 +39,21 @@ export async function getProductReviews(productId: string): Promise<Reviews[]> {
 export async function getAverageGrade(
   productId: string,
 ): Promise<number | null> {
-  const supabase = await createClient()
+  'use cache'
+
+  cacheLife('minutes')
+
+  cacheTag('products')
+  cacheTag(`product-${productId}`)
+  cacheTag(`average-grade-${productId}`)
+
+  const supabase = createStaticClient()
 
   const { data, error } = await supabase
     .from('products')
     .select('average_grade')
     .eq('id', productId)
-    .single()
+    .maybeSingle()
 
   if (error) {
     console.error('평균 평점 불러오기 실패:', error.message)

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductInfoComponent.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductInfoComponent.tsx
@@ -40,7 +40,7 @@ const ProductInfoComponent = ({
             />
 
             <div className="mt-8">
-              <ProductOption productId={product_id} />
+              <ProductOption productId={product_id} mainCategory={category} />
             </div>
           </div>
         </section>

--- a/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductOption.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/_components/Product/ProductOption.tsx
@@ -3,10 +3,17 @@ import ProductOptionClient from './ProductOptionClient'
 
 type ProductOptionProps = {
   productId: string
+  mainCategory: string
 }
 
-const ProductOption = async ({ productId }: ProductOptionProps) => {
-  const product = await getProductDetail(productId)
+const ProductOption = async ({
+  productId,
+  mainCategory,
+}: ProductOptionProps) => {
+  const product = await getProductDetail({
+    id: productId,
+    mainCategory,
+  })
 
   if (!product) return null
 

--- a/src/app/(shop)/products/[mainCategory]/[id]/page.tsx
+++ b/src/app/(shop)/products/[mainCategory]/[id]/page.tsx
@@ -1,14 +1,14 @@
-import { notFound } from 'next/navigation';
-import BreadCrumble from '../_components/BreadCrumble';
-import { isMainCategory, mainCategoryConvert } from '../lib/category';
-import ProductInfoComponent from './_components/Product/ProductInfoComponent';
-import TabInfoComponent from './_components/Tab/TabInfoComponent';
-import { getProductDetail, getStoreDetailInfo } from '@/api/productDetailApi';
-import { getAverageGrade, getProductReviews } from '@/api/review';
-import { getSellerUser } from '@/actions/getUser';
-import { Suspense } from 'react';
-import Skeleton from '../skeleton';
-import ProductListFetcher from '../_components/ProductListFetcher';
+import { notFound } from 'next/navigation'
+import BreadCrumble from '../_components/BreadCrumble'
+import { isMainCategory, mainCategoryConvert } from '../lib/category'
+import ProductInfoComponent from './_components/Product/ProductInfoComponent'
+import TabInfoComponent from './_components/Tab/TabInfoComponent'
+import { getProductDetail, getStoreDetailInfo } from '@/api/productDetailApi'
+import { getAverageGrade, getProductReviews } from '@/api/review'
+import { getSellerUser } from '@/actions/getUser'
+import { Suspense } from 'react'
+import Skeleton from '../skeleton'
+import ProductListFetcher from '../_components/ProductListFetcher'
 
 type ProductDetailPageProps = {
   params: Promise<{
@@ -26,11 +26,11 @@ export default async function ProductDetailPage({
     notFound()
   }
 
-  const categoryLabel = mainCategoryConvert[mainCategory];
-  const product = await getProductDetail(id);
-  const reviews = await getProductReviews(id);
-  const store = await getStoreDetailInfo(product.store_id);
-  const seller = await getSellerUser(store.owner_id);
+  const categoryLabel = mainCategoryConvert[mainCategory]
+  const product = await getProductDetail({ id, mainCategory })
+  const reviews = await getProductReviews(id)
+  const store = await getStoreDetailInfo({ id: product.store_id })
+  const seller = await getSellerUser(store.owner_id)
   const average_grade = await getAverageGrade(product.id)
 
   return (
@@ -43,14 +43,31 @@ export default async function ProductDetailPage({
       </h1>
       <BreadCrumble category={categoryLabel} />
       <main>
-        <ProductInfoComponent reviews={reviews} product={product} category={categoryLabel} average_grade={average_grade} />
-        <TabInfoComponent product={product} store={store} reviews={reviews} seller={seller} average_grade={average_grade} />
+        <ProductInfoComponent
+          reviews={reviews}
+          product={product}
+          category={categoryLabel}
+          average_grade={average_grade}
+        />
+        <TabInfoComponent
+          product={product}
+          store={store}
+          reviews={reviews}
+          seller={seller}
+          average_grade={average_grade}
+        />
 
         <div className="mt-15">
-          <h2 className='text-3xl font-bold mt-4 mb-4'>추천 상품</h2>
-            <Suspense fallback={<Skeleton />}>
-              <ProductListFetcher page={1} pageSize={4} mainCategory={mainCategory} sort={'latest'} pagination={false} />
-            </Suspense>
+          <h2 className="mt-4 mb-4 text-3xl font-bold">추천 상품</h2>
+          <Suspense fallback={<Skeleton />}>
+            <ProductListFetcher
+              page={1}
+              pageSize={4}
+              mainCategory={mainCategory}
+              sort={'latest'}
+              pagination={false}
+            />
+          </Suspense>
         </div>
       </main>
     </div>

--- a/src/app/(shop)/products/[mainCategory]/lib/category.ts
+++ b/src/app/(shop)/products/[mainCategory]/lib/category.ts
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation'
+
 export type MainCategoryType = 'writing' | 'paper' | 'deco' | 'office'
 
 export type CategoryItem = {
@@ -43,4 +45,29 @@ export const mainCategoryConvert: Record<MainCategoryType, string> = {
   paper: '노트/다이어리',
   deco: '데코/다꾸',
   office: '사무/데스크용품',
+}
+
+export function getMainCategoryName(mainCategory: string) {
+  if (!isMainCategory(mainCategory)) {
+    notFound()
+  }
+
+  return mainCategoryConvert[mainCategory]
+}
+
+export function getSubCategoryName(
+  mainCategory: MainCategoryType,
+  category?: string,
+) {
+  if (!category) return ''
+
+  const found = subCategory[mainCategory].find(
+    (item) => item.value === category,
+  )
+
+  if (!found) {
+    notFound()
+  }
+
+  return found.label
 }

--- a/src/app/(shop)/products/[mainCategory]/page.tsx
+++ b/src/app/(shop)/products/[mainCategory]/page.tsx
@@ -1,11 +1,11 @@
-import { notFound } from 'next/navigation';
-import { isMainCategory, mainCategoryConvert } from './lib/category';
-import BreadCrumble from './_components/BreadCrumble';
-import Sort from './_components/Sort';
-import { Suspense } from 'react';
-import ProductListFetcher from './_components/ProductListFetcher';
-import Skeleton from './skeleton';
-import FilterCategory from './_components/filterCategory';
+import { notFound } from 'next/navigation'
+import { isMainCategory, mainCategoryConvert } from './lib/category'
+import BreadCrumble from './_components/BreadCrumble'
+import Sort from './_components/Sort'
+import { Suspense } from 'react'
+import ProductListFetcher from './_components/ProductListFetcher'
+import Skeleton from './skeleton'
+import FilterCategory from './_components/filterCategory'
 
 type Product = {
   params: Promise<{
@@ -18,10 +18,13 @@ type Product = {
   }>
 }
 
-export default async function ProductListPage({ params, searchParams }: Product) {
-  const { mainCategory } = await params;
-  const { category, page = 1, sort = 'latest' } = await searchParams;
-  const MAX_PAGE_SIZE = 4;
+export default async function ProductListPage({
+  params,
+  searchParams,
+}: Product) {
+  const { mainCategory } = await params
+  const { category, page = 1, sort = 'latest' } = await searchParams
+  const MAX_PAGE_SIZE = 4
   if (!isMainCategory(mainCategory)) {
     notFound()
   }
@@ -38,12 +41,11 @@ export default async function ProductListPage({ params, searchParams }: Product)
           나만의 개성있는 문구류를 찾아보세요
         </p>
       </div>
-      <div className="flex justify-between mb-16 mt-18">
+      <div className="mt-18 mb-16 flex justify-between">
         <FilterCategory mainCategory={mainCategory} />
         <Sort />
       </div>
       <main id="main-content">
-        {/* 페이지 목록 영역 입니다 Suspense로 감싸고 안에 상품에 데이터를 전달 할 수 있도록 컴포넌트를 불러와 작성해줍니다 */}
         <Suspense fallback={<Skeleton />}>
           {/*
            * page: 현재 페이지
@@ -59,7 +61,14 @@ export default async function ProductListPage({ params, searchParams }: Product)
            * pagination true 시에 백엔드에서 totalCount를 반드시 작성해주어야 합니다.
            * 참고 파일은 api의 getProducts.ts를 참고해주세요
            */}
-          <ProductListFetcher page={page} pageSize={MAX_PAGE_SIZE} mainCategory={mainCategory} category={category} sort={sort} pagination={true} />
+          <ProductListFetcher
+            page={page}
+            pageSize={MAX_PAGE_SIZE}
+            mainCategory={mainCategory}
+            category={category}
+            sort={sort}
+            pagination={true}
+          />
         </Suspense>
       </main>
     </div>


### PR DESCRIPTION
### **PR 유형**

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**

- 상품 목록 페이지 캐싱 
- 상품상세페이지 (상품 정보/ 가게 정보/ 리뷰 ) 캐싱

### **PR 상세**

- Next.js의 `use cache`, `cacheTag`, `cacheLife`를 활용해 조회 데이터 캐싱을 적용했습니다.
- 상품 목록/상세처럼 비교적 자주 바뀌지 않는 조회 데이터는 `cacheLife`를 1시간으로 설정했습니다.
- 리뷰, 평균 평점처럼 변경 가능성이 높은 데이터는 1분 단위로 짧게 캐싱했습니다.
- 장바구니 추가/삭제는 `insert`가 발생하는 변경 작업이므로 직접 캐싱하지 않았고 revalidationPath를 추가했습니다

### **이슈번호 # **
#177 
