### PR TITLE
[FEAT] 1:1 문의 게시판 쓰기 폼 개선

### DIFF
--- a/src/actions/cartAction.ts
+++ b/src/actions/cartAction.ts
@@ -3,7 +3,6 @@
 import { createClient } from '@/utils/supabase/server'
 import { z } from 'zod'
 import { getAuthUserInfo } from './getUser'
-import { cacheLife, cacheTag, revalidatePath } from 'next/cache'
 import { SelectedOption } from '@/app/lib/cart.types'
 
 type AddCartParams = {
@@ -48,10 +47,6 @@ export type UpdateCartQuantity = z.infer<typeof updateCartQuantitySchema>
 export type DeleteCartItem = z.infer<typeof deleteCartItemSchema> // 타입 추출
 
 export async function getCarts() {
-  'use cache'
-  cacheTag('cart', 'max')
-  cacheLife('minutes')
-
   const auth = await getAuthUserInfo()
 
   if (!auth) {
@@ -122,7 +117,6 @@ export async function updateCartQuantity(input: UpdateCartQuantity) {
     console.error(error.message)
     return { success: false, message: '수량 업데이트에 실패했습니다.' }
   }
-  revalidatePath('/cart')
 
   return { success: true }
 }
@@ -177,7 +171,6 @@ export async function addCartItem({
     throw new Error(error.message)
   }
 
-  revalidatePath('/cart')
 }
 
 // 장바구니 아이템 삭제 Server Action 추가
@@ -210,8 +203,6 @@ export async function deleteCartItem(input: DeleteCartItem) {
     console.error(error.message)
     return { success: false, message: '상품 삭제에 실패했습니다.' }
   }
-
-  revalidatePath('/cart')
 
   return { success: true, message: '상품이 장바구니에서 삭제되었습니다.' }
 }

--- a/src/actions/inquireAction.ts
+++ b/src/actions/inquireAction.ts
@@ -1,12 +1,11 @@
 'use server'
 
 import { redirect } from 'next/navigation'
-// import { revalidateTag, cacheTag } from 'next/cache'
+import { revalidateTag, cacheTag } from 'next/cache'
 import { createClient } from '@/utils/supabase/server'
 import { createStaticClient } from '@/utils/supabase/static'
 import {z} from 'zod'
 import type { BoardCard, FormState } from '@/types/boards'
-import checkAdmin from '@/actions/checkAdminAction'
 
 /**
  * Zod 스키마 정의
@@ -48,8 +47,8 @@ const InquireReplySchema = z.object({
  */
 export const getInquires = async (pages: number) => {
 
-  // 'use cache'
-  // cacheTag('inquire')
+  'use cache'
+  cacheTag('inquire')
 
   // 페이지 당 게시물은 env로 제어하므로 이렇게 합니다.
   const ITEMS_PER_PAGE = Number(process.env.NEXT_PUBLIC_ITEMS_PER_PAGE) || 10
@@ -118,10 +117,6 @@ export async function handleInquireAction(
 
   try {
     if (deleteId) {
-      // 삭제 권한 검증 및 실행
-      await checkAdmin('/inquire')
-
-      // 수정 포인트 1: 테이블명 오타 수정 (qna -> qnas)
       const { error } = await supabase
         .from('qnas')
         .delete()
@@ -164,7 +159,7 @@ export async function handleInquireAction(
     }
 
     // 추후 캐싱전략을 위해 주석처리
-    // revalidateTag('inquire', { expire: 3600 })
+    revalidateTag('inquire', { expire: 3600 })
 
 
   } catch (error: unknown) {
@@ -265,7 +260,7 @@ export async function handleInquireReplyAction(
 
     if (updateError) throw updateError
 
-    // revalidateTag('inquire', { expire: 3600 })
+    revalidateTag('inquire', { expire: 3600 })
 
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : '답변 등록 중 알 수 없는 오류가 발생했습니다.'

--- a/src/actions/noticeAction.ts
+++ b/src/actions/noticeAction.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { redirect } from 'next/navigation'
-// import { revalidateTag, cacheTag } from 'next/cache'
+import { revalidateTag, cacheTag } from 'next/cache'
 import { z } from 'zod'
 import { createClient } from '@/utils/supabase/server'
 import { createStaticClient } from '@/utils/supabase/static'
@@ -33,8 +33,12 @@ const NoticeFormSchema = z.object({
  * @returns data 배열로 조회결과 생성, 필독 / 일반 공지사항
  */
 export const getNotices = async (pages: number): Promise<NoticeResponse> => {
-  // 'use cache'
-  // cacheTag('notices')
+
+  // revalidate (주기적 갱신)
+  // ISR (Incremental Static Regeneration) 점진적으로 시간이거나, 뭘할때 재생성해주는 전략.
+  'use cache'
+  cacheTag('notice')
+
 
   // env에 환경설정이랑, 캐시(정적)환경용 supabase 선언
   const ITEMS_PER_PAGE = Number(process.env.NEXT_PUBLIC_ITEMS_PER_PAGE) || 10 
@@ -152,7 +156,7 @@ export async function handleNoticeAction(
       }
     }
 
-    // revalidateTag('notices', { expire: 3600 })
+    revalidateTag('notice', { expire: 3600 })
 
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : '등록 중 알 수 없는 오류가 발생했습니다.'

--- a/src/app/(board)/inquire/[id]/page.tsx
+++ b/src/app/(board)/inquire/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getAuthUserInfo } from '@/actions/getUser'
 import sanitizeHtml from 'sanitize-html'
 import Link from 'next/link'
 import Image from 'next/image'
+import InquireDeleteAction from '@/app/components/board/InquireDeleteAction'
 
 export default async function QnaDetailPage({
   params,
@@ -60,11 +61,11 @@ export default async function QnaDetailPage({
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8 p-8">
-      <section className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
+      <section className="lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
         <div className="mb-4">
           <div className="flex w-full items-center justify-between">
             <div className="flex items-center gap-2">
-              <span className="inline-block rounded bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-600">
+              <span className="inline-block bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-600">
                 Q. 질문
               </span>
               <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{qna.title}</h1>
@@ -82,7 +83,7 @@ export default async function QnaDetailPage({
               src={qna.product?.thumbnail_image || ''}
               alt={qna.product?.name || ''}
               fill
-              className="rounded object-cover"
+              className="object-cover"
             />
           </div>
           <p className="text-sm">{qna.product?.name}</p>
@@ -98,16 +99,11 @@ export default async function QnaDetailPage({
       {(user?.role === 'ADMIN' || qna?.product?.store_id === user?.id) && (
         <div className="flex justify-end gap-2">
           {user?.role === 'ADMIN' && (
-            <Link
-              href={`/inquire/${id}/reply`}
-              className="mb-4 inline-block rounded bg-red-500 px-4 py-2 text-white hover:bg-red-700"
-            >
-              삭제하기
-            </Link>
+            <InquireDeleteAction id={qna.id} />
           )}
           <Link
             href={`/inquire/${id}/reply`}
-            className="mb-4 inline-block rounded bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
+            className="mb-4 inline-block bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
           >
             답변하기
           </Link>
@@ -115,12 +111,12 @@ export default async function QnaDetailPage({
       )}
 
       <section
-        className={`rounded-lg border p-6 shadow-sm ${qna.is_answered ? 'border-blue-100 bg-blue-50 dark:border-blue-900 dark:bg-blue-950' : 'border-dashed border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800'}`}
+        className={`lg border p-6 shadow-sm ${qna.is_answered ? 'border-blue-100 bg-blue-50 dark:border-blue-900 dark:bg-blue-950' : 'border-dashed border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800'}`}
       >
         {qna.is_answered ? (
           <>
             <div className="mb-4 flex items-center justify-between">
-              <span className="inline-block rounded bg-green-100 px-2 py-1 text-xs font-semibold text-green-600">
+              <span className="inline-block bg-green-100 px-2 py-1 text-xs font-semibold text-green-600">
                 A. 답변 완료
               </span>
               {qna.answered_at && (
@@ -164,17 +160,20 @@ export default async function QnaDetailPage({
       {/* 수정 및 목록 버튼 */}
       <div className="flex justify-end gap-2">
         {(user?.role === 'ADMIN' || qna?.writer_id === user?.id) && (
-          <Link
-            href={`/inquire/${id}/edit`}
-            className="mb-4 inline-block rounded bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
-          >
-            수정
-          </Link>
+          <div className='flex gap-2'>
+            <InquireDeleteAction id={qna.id} />
+            <Link
+              href={`/inquire/${id}/edit`}
+              className="inline-block bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
+            >
+              수정
+            </Link>
+          </div>
         )}
 
         <Link
           href="/inquire"
-          className="mb-4 inline-block rounded bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
+          className="inline-block bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
         >
           목록
         </Link>

--- a/src/app/(board)/inquire/write/page.tsx
+++ b/src/app/(board)/inquire/write/page.tsx
@@ -1,12 +1,16 @@
-// app/inquire/write/page.tsx
 import WriteForm from '@/app/components/board/WriteForm'
 import { handleInquireAction } from '@/actions/inquireAction'
 import InquireFindProdctAction from '@/app/components/board/InquireFindProdctAction'
+import ProductInfo from '@/app/components/board/ProductInfo'
 
 export default function NoticeWritePage() {
+
+
   return (
     <div className="container mx-auto py-10 max-w-6xl flex flex-col gap-6">
       <InquireFindProdctAction />
+
+      <ProductInfo />
 
       <WriteForm
         type="inquire"

--- a/src/app/(shop)/cart/_components/CartDeleteButton.tsx
+++ b/src/app/(shop)/cart/_components/CartDeleteButton.tsx
@@ -1,25 +1,30 @@
 'use client'
 
-import { X } from 'lucide-react'
+import { X, Loader2 } from 'lucide-react'
 import { deleteCartItem } from '@/actions/cartAction'
+import { useTransition } from 'react'
 
 export default function CartDeleteButton({ deleteId }: { deleteId: string }) {
 
-  const handleDeleteAction = async (id: string) => {
-    const result = await deleteCartItem({ cartItemId: id })
+  const [isPending, startTransition] = useTransition()
 
-    if (!result.success) {
-      alert(result.message)
-    }
+  const handleDeleteAction = (id: string) => {
+    startTransition(async () => {
+      const result = await deleteCartItem({ cartItemId: id })
+      if (!result.success) {
+        alert(result.message)
+      }
+    })
   }
 
   return (
     <button
-      className='w-10 h-10 flex justify-center items-center cursor-pointer text-gray-400 hover:text-black transition-colors'
+      className='w-10 h-10 flex justify-center items-center cursor-pointer text-gray-400 hover:text-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
       onClick={() => handleDeleteAction(deleteId)}
+      disabled={isPending}
       aria-label="상품 삭제"
     >
-      <X />
+      {isPending ? <Loader2 className="animate-spin" size={20} /> : <X />}
     </button>
   )
 }

--- a/src/app/(shop)/cart/page.tsx
+++ b/src/app/(shop)/cart/page.tsx
@@ -6,6 +6,8 @@ import CartDeleteButton from "./_components/CartDeleteButton"
 import Link from "next/link"
 import { ShoppingBag } from "lucide-react"
 
+import ProductImage from "../products/[mainCategory]/_components/ProductImage"
+
 export default async function CartList() {
 
   const cart = await getCarts()
@@ -35,10 +37,9 @@ export default async function CartList() {
           <li key={item.id} className="flex items-start gap-4 p-4 relative">
             {/* 상품 이미지 */}
             <div className="relative w-20 h-20 sm:w-24 sm:h-24 shrink-0 bg-gray-100 rounded-md overflow-hidden">
-              <Image
+              <ProductImage
                 src={item.product?.thumbnail_image || ''}
                 alt={item.product?.name || ''}
-                fill
               />
             </div>
 

--- a/src/app/(shop)/cart/page.tsx
+++ b/src/app/(shop)/cart/page.tsx
@@ -1,6 +1,5 @@
 import { getCarts } from "@/actions/cartAction"
 import QuantityComponent from "./_components/Quantity"
-import Image from "next/image"
 import PriceBox from "./_components/PriceBox"
 import CartDeleteButton from "./_components/CartDeleteButton"
 import Link from "next/link"

--- a/src/app/(shop)/payment/_components/AddressSection.tsx
+++ b/src/app/(shop)/payment/_components/AddressSection.tsx
@@ -65,8 +65,10 @@ export default function AddressSection({ userInfo }: { userInfo: UserInfo }) {
       </fieldset>
 
       <div className="mt-2">
+        <span className="font-semibold text-sm">배송지 *</span>
         {mode === 'saved' ? (
           <div className="">
+
             <input type='hidden' name='zipCode' />
             <input type='hidden' name='detailAdr' />
             <input type='text' name='streetAdr' className="mt-1 rounded border border-gray-300 bg-white px-3 py-2.5 focus:outline-none focus:border-gray-500 w-full dark:bg-gray-500 dark:text-white dark:placeholder:text-white dark:focus-within:bg-gray-900" value={userInfo?.address} readOnly />

--- a/src/app/(shop)/payment/_components/AddressSection.tsx
+++ b/src/app/(shop)/payment/_components/AddressSection.tsx
@@ -35,7 +35,7 @@ export default function AddressSection({ userInfo }: { userInfo: UserInfo }) {
 
         <div className="flex gap-8">
           <div className="flex flex-col w-full max-w-[320px]">
-            <label htmlFor="userName" className="font-semibold text-sm">주문자 이름 *</label>
+            <label htmlFor="userName" className="font-semibold text-sm">주문자 이름 <span className='text-red-500'>*</span></label>
             <input
               type="text"
               id="userName"
@@ -48,7 +48,7 @@ export default function AddressSection({ userInfo }: { userInfo: UserInfo }) {
             />
           </div>
           <div className="flex flex-col w-full max-w-[320px]">
-            <label htmlFor="phone" className="font-semibold text-sm">연락처 *</label>
+            <label htmlFor="phone" className="font-semibold text-sm">연락처 <span className='text-red-500'>*</span></label>
             <input
               type="tel"
               id="phone"
@@ -64,7 +64,7 @@ export default function AddressSection({ userInfo }: { userInfo: UserInfo }) {
       </fieldset>
 
       <div className="mt-2">
-        <span className="font-semibold text-sm">배송지 *</span>
+        <p className="font-semibold text-sm">배송지 <span className='text-red-500'>*</span></p>
         {mode === 'saved' ? (
           <div className="">
             <input type='hidden' name='zipCode' />

--- a/src/app/(shop)/payment/_components/AddressSection.tsx
+++ b/src/app/(shop)/payment/_components/AddressSection.tsx
@@ -34,7 +34,6 @@ export default function AddressSection({ userInfo }: { userInfo: UserInfo }) {
         </div>
 
         <div className="flex gap-8">
-          {/* 이름, 연락처 영역 생략 (기존과 동일) */}
           <div className="flex flex-col w-full max-w-[320px]">
             <label htmlFor="userName" className="font-semibold text-sm">주문자 이름 *</label>
             <input
@@ -68,7 +67,6 @@ export default function AddressSection({ userInfo }: { userInfo: UserInfo }) {
         <span className="font-semibold text-sm">배송지 *</span>
         {mode === 'saved' ? (
           <div className="">
-
             <input type='hidden' name='zipCode' />
             <input type='hidden' name='detailAdr' />
             <input type='text' name='streetAdr' className="mt-1 rounded border border-gray-300 bg-white px-3 py-2.5 focus:outline-none focus:border-gray-500 w-full dark:bg-gray-500 dark:text-white dark:placeholder:text-white dark:focus-within:bg-gray-900" value={userInfo?.address} readOnly />

--- a/src/app/(shop)/payment/_components/PaymentSeletor.tsx
+++ b/src/app/(shop)/payment/_components/PaymentSeletor.tsx
@@ -1,0 +1,23 @@
+import { CreditCard, BanknoteArrowUp } from "lucide-react"
+
+export default function PaymentSelector() {
+  return (
+    <fieldset className="flex gap-2">
+      <legend className="sr-only">결제 방식 선택</legend>
+
+      <label className="flex flex-col items-center justify-center w-full p-4 border rounded cursor-pointer text-gray-400 hover:text-gray-500 focus-within:ring-2 focus-within:ring-gray-500 text-center has-checked:border-black-600 has-checked:border-2 has-checked:text-black dark:has-checked:text-gray-200">
+        <input type="radio" name="paymentMethod" value="PAID" className="sr-only" required />
+        <CreditCard aria-hidden="true" size={36} />
+        <span className="font-bold text-lg mt-2">신용/체크카드</span>
+        <span className="text-sm opacity-70">모든 카드 결제 가능</span>
+      </label>
+
+      <label className="flex flex-col items-center justify-center w-full p-4 border rounded cursor-pointer text-gray-400 hover:text-gray-500 focus-within:ring-2 focus-within:ring-gray-500 text-center has-checked:border-black-600 has-checked:border-2 has-checked:text-black dark:has-checked:text-gray-200">
+        <input type="radio" name="paymentMethod" value="PENDING" className="sr-only" required />
+        <BanknoteArrowUp aria-hidden="true" size={36} />
+        <span className="font-bold text-lg mt-2">무통장 입금</span>
+        <span className="text-sm opacity-70">계좌이체 결제</span>
+      </label>
+    </fieldset>
+  )
+}

--- a/src/app/(shop)/payment/_components/PaymentSubmitButton.tsx
+++ b/src/app/(shop)/payment/_components/PaymentSubmitButton.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+import { Loader2 } from 'lucide-react'
+
+export default function PaymentSubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className={`w-full mt-6 py-4 rounded-md font-bold transition-colors flex justify-center items-center gap-2 ${
+        pending
+          ? 'bg-gray-400 cursor-not-allowed text-white'
+          : 'bg-black text-white cursor-pointer hover:bg-gray-800 dark:bg-gray-600 dark:hover:bg-gray-500'
+      }`}
+    >
+      {pending ? (
+        <>
+          <Loader2 className="animate-spin" size={20} />
+          결제 처리 중...
+        </>
+      ) : (
+        '결제하기'
+      )}
+    </button>
+  )
+}

--- a/src/app/(shop)/payment/_components/TotalPriceBox.tsx
+++ b/src/app/(shop)/payment/_components/TotalPriceBox.tsx
@@ -32,12 +32,10 @@ export default function TotalPriceBox({ cart, totalOriginPrice, totalDiscountedP
           {cart.map((item) => {
             const product = item.product
             const productPrice = product?.price ?? 0
-            const discountRate = product?.discount_rate ?? 0 // 안전하게 기본값 0 처리
-
-            // 한 품목의 최종 가격 계산
+            const discountRate = product?.discount_rate ?? 0
             const itemFinalPrice = (productPrice * (1 - discountRate / 100)) * item.quantity
 
-            // 옵션 렌더링을 위한 준비
+            // 옵션이 {"option": "value"}이기에 준비
             const selectedOptionsEntries = item.selected_options ? Object.entries(item.selected_options) : []
 
             return (
@@ -51,7 +49,6 @@ export default function TotalPriceBox({ cart, totalOriginPrice, totalDiscountedP
                   </span>
                 </div>
 
-                {/* 선택 옵션 표시 */}
                 {selectedOptionsEntries.length > 0 && (
                   <div className="text-xs text-gray-400 mt-0.5">
                     {selectedOptionsEntries.map(([key, value], idx) => (
@@ -62,7 +59,6 @@ export default function TotalPriceBox({ cart, totalOriginPrice, totalDiscountedP
                   </div>
                 )}
 
-                {/* 상품별 가격 표시 */}
                 <div className="flex justify-end mt-1">
                   <span className="text-sm font-semibold text-gray-700 dark:text-gray-400">
                     {itemFinalPrice.toLocaleString()}원

--- a/src/app/(shop)/payment/_components/TotalPriceBox.tsx
+++ b/src/app/(shop)/payment/_components/TotalPriceBox.tsx
@@ -1,4 +1,4 @@
-
+import PaymentSubmitButton from './PaymentSubmitButton'
 interface CartItem {
   id: string
   product_id: string
@@ -92,16 +92,7 @@ export default function TotalPriceBox({ cart, totalOriginPrice, totalDiscountedP
         </div>
       </dl>
 
-      {/* 값을 보내기 위한 hidden Input */}
-      <div>
-        <input type="hidden" name="totalOriginPrice" />
-        <input type="hidden" name="totalDiscountAmount" />
-        <input type="hidden" name="totalDiscountedPrice" />
-      </div>
-
-      <button type="submit" form="payment-form" className="w-full mt-6 bg-black text-white py-4 rounded-md font-bold cursor-pointer dark:bg-gray-600">
-        결제하기
-      </button>
+      <PaymentSubmitButton />
     </section>
   )
 }

--- a/src/app/(shop)/payment/page.tsx
+++ b/src/app/(shop)/payment/page.tsx
@@ -25,8 +25,9 @@ export default async function Payment() {
   }, 0);
 
   return (
-    <div className="max-w-7xl mx-auto flex gap-6 py-6">
-      <form id="payment-form" action={submitPayment} method="POST" className="w-full flex flex-col gap-6">
+    <div className="max-w-7xl mx-auto py-6">
+      <form id="payment-form" action={submitPayment} method="POST" className="flex gap-6">
+        <div className="w-full flex flex-col gap-6">
 
         {/* --- 주문자 정보 영역 --- */}
         <fieldset className="flex flex-col gap-3">
@@ -51,7 +52,7 @@ export default async function Payment() {
             <span className="text-sm opacity-70">계좌이체 결제</span>
           </label>
         </fieldset>
-      </form>
+        </div>
 
       <aside className="w-1/3 min-w-75">
         <TotalPriceBox
@@ -60,6 +61,7 @@ export default async function Payment() {
           totalDiscountedPrice={totalDiscountedPrice}
         />
       </aside>
+      </form>
     </div>
   )
 }

--- a/src/app/(shop)/payment/page.tsx
+++ b/src/app/(shop)/payment/page.tsx
@@ -2,9 +2,9 @@ import { getCarts } from "@/actions/cartAction"
 import TotalPriceBox from "./_components/TotalPriceBox"
 import AddressSection from "./_components/AddressSection"
 import { getLocationUserInfo, submitPayment } from "@/actions/paymentAction"
-import { CreditCard, BanknoteArrowUp } from "lucide-react"
 import type { UserInfo } from "@/types/orders"
 import { redirect } from 'next/navigation'
+import PaymentSelector from "./_components/PaymentSeletor"
 
 
 export default async function Payment() {
@@ -29,38 +29,22 @@ export default async function Payment() {
       <form id="payment-form" action={submitPayment} method="POST" className="flex gap-6">
         <div className="w-full flex flex-col gap-6">
 
-        {/* --- 주문자 정보 영역 --- */}
-        <fieldset className="flex flex-col gap-3">
-          <AddressSection userInfo={userInfo} />
-        </fieldset>
+          {/* 주문영역 */}
+          <fieldset className="flex flex-col gap-3">
+            <AddressSection userInfo={userInfo} />
+          </fieldset>
 
-        {/* --- 결제 방식 선택 영역 --- */}
-        <fieldset className="flex gap-2">
-          <legend className="sr-only">결제 방식 선택</legend>
-
-          <label className="flex flex-col items-center justify-center w-full p-4 border rounded cursor-pointer hover:text-gray-500 focus-within:ring-2 focus-within:ring-gray-500 text-center">
-            <input type="radio" name="paymentMethod" value="PAID" className="sr-only" required />
-            <CreditCard aria-hidden="true" size={36} />
-            <span className="font-bold text-lg mt-2">신용/체크카드</span>
-            <span className="text-sm opacity-70">모든 카드 결제 가능</span>
-          </label>
-
-          <label className="flex flex-col items-center justify-center w-full p-4 border rounded cursor-pointer hover:text-gray-500 focus-within:ring-2 focus-within:ring-gray-500 text-center">
-            <input type="radio" name="paymentMethod" value="PENDING" className="sr-only" required />
-            <BanknoteArrowUp aria-hidden="true" size={36} />
-            <span className="font-bold text-lg mt-2">무통장 입금</span>
-            <span className="text-sm opacity-70">계좌이체 결제</span>
-          </label>
-        </fieldset>
+          {/* 결제방식 */}
+          <PaymentSelector />
         </div>
 
-      <aside className="w-1/3 min-w-75">
-        <TotalPriceBox
-          cart={cart}
-          totalOriginPrice={totalOriginPrice}
-          totalDiscountedPrice={totalDiscountedPrice}
-        />
-      </aside>
+        <aside className="w-1/3 min-w-75">
+          <TotalPriceBox
+            cart={cart}
+            totalOriginPrice={totalOriginPrice}
+            totalDiscountedPrice={totalDiscountedPrice}
+          />
+        </aside>
       </form>
     </div>
   )

--- a/src/app/(shop)/payment/page.tsx
+++ b/src/app/(shop)/payment/page.tsx
@@ -26,7 +26,7 @@ export default async function Payment() {
 
   return (
     <div className="max-w-7xl mx-auto py-6">
-      <form id="payment-form" action={submitPayment} method="POST" className="flex gap-6">
+      <form id="payment-form" action={submitPayment} className="flex gap-6">
         <div className="w-full flex flex-col gap-6">
 
           {/* 주문영역 */}

--- a/src/app/components/board/InquireDeleteAction.tsx
+++ b/src/app/components/board/InquireDeleteAction.tsx
@@ -4,15 +4,15 @@ import { useFormStatus } from 'react-dom'
 import { Loader2 } from 'lucide-react'
 import { useState, useActionState } from 'react'
 import Modal from '@/app/components/Modal'
-import { handleNoticeAction } from '@/actions/noticeAction'
+import { handleInquireAction } from '@/actions/inquireAction'
 
-interface NoticeDeleteActionProps {
+interface InquireDeleteActionProps {
   id: string
 }
 
-export default function NoticeDeleteAction({ id }: NoticeDeleteActionProps) {
+export default function InquireDeleteAction({ id }: InquireDeleteActionProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [state, formAction] = useActionState(handleNoticeAction, {
+  const [state, formAction] = useActionState(handleInquireAction, {
     success: true,
     message: '',
   })
@@ -31,7 +31,7 @@ export default function NoticeDeleteAction({ id }: NoticeDeleteActionProps) {
       <Modal
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
-        title="공지사항 삭제"
+        title="1:1문의글 삭제"
         footer={
           <div className="flex gap-2">
             <button
@@ -42,6 +42,7 @@ export default function NoticeDeleteAction({ id }: NoticeDeleteActionProps) {
             </button>
 
             <form action={formAction}>
+              {/* 삭제할 ID를 hidden input으로 전달 */}
               <input type="hidden" name="deleteId" value={id} />
               <button
                 type="submit"
@@ -61,7 +62,7 @@ export default function NoticeDeleteAction({ id }: NoticeDeleteActionProps) {
         }
       >
         <p className="py-4 text-gray-600">
-          정말로 이 공지사항을 삭제하시겠습니까?
+          정말로 이 게시글을 삭제하시겠습니까?
           <br />
           삭제된 데이터는 복구할 수 없습니다.
         </p>

--- a/src/app/components/board/PostListCard.tsx
+++ b/src/app/components/board/PostListCard.tsx
@@ -1,11 +1,11 @@
 import type { BoardCard } from '@/types/boards'
-import Image from 'next/image'
 import Link from 'next/link'
+import ProductImage from '@/app/(shop)/products/[mainCategory]/_components/ProductImage'
 
 interface PostCardList {
   data: BoardCard
   isImportant?: boolean
-  isAnswered?: boolean // 💡 1. 타입 정의 추가 (선택적 프로퍼티)
+  isAnswered?: boolean
   link: string
 }
 
@@ -28,11 +28,9 @@ export default function PostListCard({
         {link === 'inquire' && (
           <div className="flex w-full items-center gap-2 xl:w-1/3">
             <div className="relative h-10 w-10 shrink-0 xl:h-16 xl:w-16">
-              <Image
+              <ProductImage
                 src={data.product?.thumbnail_image || ''}
                 alt={data.product?.name || ''}
-                fill
-                className="rounded object-cover"
               />
             </div>
             <p className="text-sm">{data.product?.name}</p>
@@ -41,7 +39,6 @@ export default function PostListCard({
 
         <div className="flex w-full">
           <div className="flex w-1/2 items-center justify-start gap-1">
-            {/* 공지사항 중요 배지 */}
             {important && (
               <strong
                 className="shrink-0 bg-orange-600 px-2 py-1 text-xs font-normal text-white"
@@ -51,7 +48,6 @@ export default function PostListCard({
               </strong>
             )}
 
-            {/* 💡 2. QnA 답변 상태 배지: isAnswered가 undefined가 아닐 때만 렌더링 */}
             {isAnswered !== undefined &&
               (isAnswered ? (
                 <strong

--- a/src/app/components/board/ProductInfo.tsx
+++ b/src/app/components/board/ProductInfo.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import ProductImage from "@/app/(shop)/products/[mainCategory]/_components/ProductImage"
+import { useInquireStore } from "@/store/useInquireStore"
+
+export default function ProductInfo() {
+
+  const { selectedProduct, setSelectedProduct } = useInquireStore()
+
+  if (!selectedProduct) {
+    return (
+      <div className="mt-4 p-4 rounded-lg border text-gray-500 bg-gray-50 text-center text-sm">
+        선택된 상품이 없습니다. 상품을 검색하여 선택해주세요.
+      </div>
+    )
+  }
+
+  function handleRemoveProduct() {
+    setSelectedProduct(null)
+  }
+
+
+  return (
+    <div>
+      <p className="text-blue-500 font-semibold mb-4">선택된 상품</p>
+      <div className="w-full flex justify-between items-center">
+        <div className="flex items-center gap-3">
+          <div className="w-16 h-16 relative">
+            <ProductImage src={selectedProduct.thumbnail_image} alt={selectedProduct.name} />
+          </div>
+          <p className="font-bold text-gray-900">{selectedProduct.name}</p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleRemoveProduct}
+          className="bg-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300 h-12"
+        >
+          선택 취소
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/board/SearchProducts.tsx
+++ b/src/app/components/board/SearchProducts.tsx
@@ -54,10 +54,12 @@ export default function SearchProducts({ onSelectClose }: SearchProductsProps) {
               key={item.id}
               className="flex items-center justify-between p-4"
             >
-              <div className="relative w-14 h-14">
-                <ProductImage src={item.thumbnail_image} alt={item.name} />
+              <div className="flex gap-4 items-center">
+                <div className="relative w-14 h-14">
+                  <ProductImage src={item.thumbnail_image} alt={item.name} />
+                </div>
+                <p className="font-bold">{item.name}</p>
               </div>
-              <p className="font-bold">{item.name}</p>
               <button
                 type="button"
                 onClick={() => handleAddProduct(item)}

--- a/src/app/components/board/SearchProducts.tsx
+++ b/src/app/components/board/SearchProducts.tsx
@@ -2,7 +2,8 @@
 import { useActionState } from 'react'
 import { Search, Loader2 } from 'lucide-react'
 import SearchProductsAction, { SearchState } from '@/api/searchProducts'
-import { useInquireStore } from '@/store/useInquireStore'
+import { useInquireStore, Product } from '@/store/useInquireStore'
+import ProductImage from "@/app/(shop)/products/[mainCategory]/_components/ProductImage"
 
 const initialState: SearchState = { success: false, message: '', data: [] }
 
@@ -18,7 +19,7 @@ export default function SearchProducts({ onSelectClose }: SearchProductsProps) {
 
   const { selectedProduct, setSelectedProduct } = useInquireStore()
 
-  function handleAddProduct(item: string) {
+  function handleAddProduct(item: Product) {
     setSelectedProduct(item)
     if (onSelectClose) onSelectClose()
   }
@@ -33,7 +34,6 @@ export default function SearchProducts({ onSelectClose }: SearchProductsProps) {
           placeholder="제품명을 입력해주세요"
           disabled={isPending}
         />
-
         <button
           type="submit"
           disabled={isPending}
@@ -47,30 +47,32 @@ export default function SearchProducts({ onSelectClose }: SearchProductsProps) {
         <p className="mt-2 text-sm text-red-500">{state.message}</p>
       )}
 
-      <ul className="mt-4 flex flex-col gap-2">
+      <ul className="mt-4 flex flex-col gap-2 divide-y divide-gray-400">
         {state.data && state.data.length > 0
           ? state.data.map((item) => (
-              <li
-                key={item.id}
-                className="flex items-center justify-between rounded-lg border p-4 shadow-sm"
-              >
-                <p className="font-bold">{item.name}</p>
-                <button
-                  type="button"
-                  onClick={() => handleAddProduct(item.id)}
-                  className={`rounded-lg px-4 py-2 text-sm ${
-                    selectedProduct === item.id
-                      ? 'bg-blue-500 text-white'
-                      : 'bg-gray-200 hover:bg-gray-300'
+            <li
+              key={item.id}
+              className="flex items-center justify-between p-4"
+            >
+              <div className="relative w-14 h-14">
+                <ProductImage src={item.thumbnail_image} alt={item.name} />
+              </div>
+              <p className="font-bold">{item.name}</p>
+              <button
+                type="button"
+                onClick={() => handleAddProduct(item)}
+                className={`rounded-lg px-4 py-2 text-sm ${selectedProduct?.id === item.id
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 hover:bg-gray-300'
                   }`}
-                >
-                  {selectedProduct === item.id ? '선택됨' : '선택하기'}
-                </button>
-              </li>
-            ))
+              >
+                {selectedProduct?.id === item.id ? '선택됨' : '선택하기'}
+              </button>
+            </li>
+          ))
           : state.success && (
-              <li className="p-4 text-gray-500">검색 결과가 없습니다.</li>
-            )}
+            <li className="p-4 text-gray-500">검색 결과가 없습니다.</li>
+          )}
       </ul>
     </div>
   )

--- a/src/app/components/board/WriteForm.tsx
+++ b/src/app/components/board/WriteForm.tsx
@@ -88,7 +88,7 @@ export default function WriteForm({
     <form
       action={formAction}
       onSubmit={handleSubmit}
-      className="mx-auto flex w-full max-w-6xl flex-col gap-6 rounded-lg p-6 shadow-sm"
+      className="mx-auto flex w-full max-w-6xl flex-col gap-6"
     >
       {/* 질문 작성 시 제품정보 위한 히든 input 추가 */}
       {type === 'inquire' && (
@@ -96,7 +96,7 @@ export default function WriteForm({
           type="hidden"
           name="product"
           id="product"
-          value={selectedProduct || ''}
+          value={selectedProduct?.id || ''}
         />
       )}
 

--- a/src/store/useInquireStore.ts
+++ b/src/store/useInquireStore.ts
@@ -1,11 +1,18 @@
 import { create } from 'zustand'
 
+export interface Product {
+  id: string
+  name: string
+  price: number
+  thumbnail_image: string
+}
+
 interface InquireState {
-  selectedProduct: string
-  setSelectedProduct: (product: string) => void
+  selectedProduct: Product | null
+  setSelectedProduct: (product: Product | null) => void
 }
 
 export const useInquireStore = create<InquireState>((set) => ({
-  selectedProduct: '',
+  selectedProduct: null,
   setSelectedProduct: (product) => set({ selectedProduct: product }),
 }))


### PR DESCRIPTION
### **PR 유형**

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 상세**

<img width="676" height="303" alt="스크린샷 2026-05-15 오후 2 52 50" src="https://github.com/user-attachments/assets/135e1c57-0e3b-479d-ad47-f08f348db53f" />
<img width="667" height="309" alt="스크린샷 2026-05-15 오후 2 53 05" src="https://github.com/user-attachments/assets/b6b781d8-d47e-43cb-b1c1-0484aac34798" />

게시글 검색 시 썸네일 출력도 추가했습니다.
기존 성윤님이 제작해주신 썸네일 출력 컴포넌트로 사용했습니다.

<img width="978" height="735" alt="스크린샷 2026-05-15 오후 2 51 54" src="https://github.com/user-attachments/assets/a63f7ce0-be9b-4b03-b642-dcb73cebf41a" />
또한 zustand의 store 구조를 변경해 제품 정보를 담개해서
선택후에 제품 정보가 노출되도록 했습니다.


### **이슈번호 # **
#184 
