### PR TITLE
[FIX] 201 마이페이지 스켈레톤 무한로딩 에러 해결 

### DIFF
--- a/src/app/components/Navi.tsx
+++ b/src/app/components/Navi.tsx
@@ -11,7 +11,7 @@ export default function Navi() {
       {/* 쿠폰 */}
       {/* 로그인 여부에 따라 해당 쿠폰 표출/비표출 */}
       <Link
-        href={'/coupon'}
+        href={'/mypage/consumer/coupons'}
         className="flex bg-black px-8 py-2 text-sm text-white focus:z-30"
       >
         🎉 신규가입 시 5,000원 할인쿠폰 증정!

--- a/src/app/mypage/actions/summaryAction.ts
+++ b/src/app/mypage/actions/summaryAction.ts
@@ -1,16 +1,18 @@
 'use server'
 
+import { connection } from 'next/server' 
 import { createClient } from '@/utils/supabase/server'
 
 export async function getSummaryData(
   userId: string,
   role: 'USER' | 'BUSINESS',
 ) {
+  await connection()
+
   const supabase = await createClient()
 
   try {
     if (role === 'USER') {
-      // 소비자의 경우: 주문 내역, 남은 쿠폰, 찜한 상품에서 갯수를 가져옵니다.
       const [orders, coupons, wishlist] = await Promise.all([
         supabase
           .from('orders')
@@ -28,12 +30,11 @@ export async function getSummaryData(
       ])
 
       return {
-        count1: orders.count || 0,
-        count2: coupons.count || 0,
-        text3: String(wishlist.count || 0),
+        count1: orders.count ?? 0,
+        count2: coupons.count ?? 0,
+        text3: String(wishlist.count ?? 0),  // 숫자를 문자열로 변환
       }
     } else {
-      // 판매자의 경우: 주문 현황, 등록 상품의 갯수와 상점명을 가져옵니다.
       const { data: store, error: storeError } = await supabase
         .from('stores')
         .select('id, name')
@@ -45,11 +46,11 @@ export async function getSummaryData(
         return { count1: 0, count2: 0, text3: '상점 없음' }
       }
 
-      // 상점 ID를 기준으로 주문과 상품 개수를 가져옵니다.
       const [orderItemsResult, productsResult] = await Promise.all([
+        // products 테이블을 거치지 않고 store_id로 바로 조회
         supabase
           .from('order_items')
-          .select('id, products!inner(store_id)')
+          .select('id, product_id, products!inner(store_id)')
           .eq('products.store_id', store.id),
         supabase
           .from('products')
@@ -57,9 +58,17 @@ export async function getSummaryData(
           .eq('store_id', store.id),
       ])
 
+      // 에러 로깅 추가
+      if (orderItemsResult.error) {
+        console.error('주문 조회 에러:', orderItemsResult.error)
+      }
+      if (productsResult.error) {
+        console.error('상품 조회 에러:', productsResult.error)
+      }
+
       return {
-        count1: orderItemsResult.data?.length || 0,
-        count2: productsResult.count || 0,
+        count1: orderItemsResult.data?.length ?? 0,
+        count2: productsResult.count ?? 0,
         text3: store.name,
       }
     }

--- a/src/app/mypage/components/SummaryMenu.tsx
+++ b/src/app/mypage/components/SummaryMenu.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { startTransition, useEffect, useState } from 'react'
 import { useUser } from '../context/UserContext'
 import { getSummaryData } from '../actions/summaryAction'
 import StatCard from './StatCard'
@@ -12,6 +12,7 @@ import {
   ClipboardList,
 } from 'lucide-react'
 import { StatData } from '../types/user'
+import { usePathname } from 'next/navigation'
 
 const CONSUMER_PATH = '/mypage/consumer'
 const SELLER_PATH = '/mypage/seller'
@@ -60,6 +61,8 @@ const STATS_CONFIG: Record<'USER' | 'BUSINESS', StatData[]> = {
 }
 
 export default function SummaryMenu() {
+  const pathname = usePathname()
+
   const { role, user, isLoading: isUserLoading } = useUser()
   const [data, setData] = useState({ count1: 0, count2: 0, text3: '' })
   const [isDataLoading, setIsDataLoading] = useState(true)
@@ -67,6 +70,11 @@ export default function SummaryMenu() {
   const userId = user?.id
 
   useEffect(() => {
+    if (!isUserLoading && !userId) {
+      startTransition(() => setIsDataLoading(false))
+      return
+    }
+
     // 초기 로딩 중이거나 필수 정보가 없으면 실행 중단
     if (isUserLoading || !userId || !role) return
 
@@ -74,6 +82,7 @@ export default function SummaryMenu() {
 
     async function loadData() {
       setIsDataLoading(true)
+
       try {
         // 여기서 userId가 string임을 한 번 더 확실히 체크합니다.
         // 이렇게 하면 getSummaryData에 들어가는 인자가 절대 undefined일 수 없음을 TS가 인지합니다.
@@ -90,9 +99,7 @@ export default function SummaryMenu() {
       } catch (error) {
         console.error('데이터 연동 실패:', error)
       } finally {
-        if (isMounted) {
-          setIsDataLoading(false)
-        }
+        setIsDataLoading(false)
       }
     }
 
@@ -100,10 +107,11 @@ export default function SummaryMenu() {
     return () => {
       isMounted = false
     }
-  }, [userId, role, isUserLoading])
+  }, [userId, role, isUserLoading, pathname])
 
   // 데이터가 이미 존재한다면 스켈레톤을 보여주지 않도록 순서 제어
   const hasData = data.count1 !== 0 || data.count2 !== 0 || data.text3 !== ''
+
 
   if ((isUserLoading || isDataLoading) && !hasData) {
     return (

--- a/src/app/mypage/consumer/profile/components/ImageUploader.tsx
+++ b/src/app/mypage/consumer/profile/components/ImageUploader.tsx
@@ -59,7 +59,6 @@ export default function ImageUploader({
 
       // 부모 컴포넌트(Info.tsx)의 setFormData를 실행하기 위해 콜백 함수를 호출합니다.
       if (onUploadSuccess) {
-        console.log('이미지 업로드 성공! URL:', publicUrl)
         onUploadSuccess(publicUrl)
       }
     } catch (error) {

--- a/src/app/mypage/consumer/profile/page.tsx
+++ b/src/app/mypage/consumer/profile/page.tsx
@@ -107,7 +107,6 @@ export default function Profile() {
             label="프로필 이미지"
             defaultImage={formData.profileImage}
             onUploadSuccess={(url) => {
-              console.log('업로드된 이미지 URL:', url)
               setFormData((prev) => ({ ...prev, profileImage: url }))
             }}
             isEditing={isEditing}

--- a/src/app/mypage/context/UserContext.tsx
+++ b/src/app/mypage/context/UserContext.tsx
@@ -38,11 +38,9 @@ export function UserProvider({
   children: ReactNode
   initialUser?: User | null
 }) {
-  const [authState, setAuthState] = useState<UserContextType>({
-    user: initialUser ?? null,
-    role: (initialUser?.role as Role) ?? null,
-    isLoading: initialUser ? false : true,
-  })
+  // initialUser가 없을 때만 클라이언트 fetch 결과를 담는 state
+  const [fetchedUser, setFetchedUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(!initialUser)
 
   useEffect(() => {
     if (initialUser) return // 서버에서 이미 받았으면 스킵
@@ -51,10 +49,12 @@ export function UserProvider({
 
     const fetchFullUserData = async () => {
       try {
-        const { data: { user: authUser } } = await supabase.auth.getUser()
+        const {
+          data: { user: authUser },
+        } = await supabase.auth.getUser()
 
         if (!authUser) {
-          setAuthState({ user: null, role: null, isLoading: false })
+          setIsLoading(false)
           return
         }
 
@@ -80,26 +80,28 @@ export function UserProvider({
             }
           }
 
-          setAuthState({
-            user: finalUserData,
-            role: profile.role as Role,
-            isLoading: false,
-          })
-        } else {
-          // 핵심 수정: profile이 null이어도 isLoading을 false로 변경
-          setAuthState({ user: null, role: null, isLoading: false })
+          setFetchedUser(finalUserData)
         }
       } catch (error) {
         console.error('User fetch error:', error)
-        // catch에서도 isLoading: false 보장 (기존 유지)
-        setAuthState((prev) => ({ ...prev, isLoading: false }))
+      } finally {
+        setIsLoading(false)
       }
     }
 
     fetchFullUserData()
-  }, [initialUser]) // 마운트 시 1회만 실행
+  }, [initialUser])
 
-  const value = useMemo(() => authState, [authState])
+  // initialUser(서버)가 있으면 그걸 우선 사용, 없으면 클라이언트 fetch 결과 사용
+  // initialUser?.id가 바뀌면 자동으로 새 값으로 파생됨 → useEffect 불필요
+  const value = useMemo<UserContextType>(() => {
+    const activeUser = initialUser ?? fetchedUser
+    return {
+      user: activeUser,
+      role: (activeUser?.role as Role) ?? null,
+      isLoading,
+    }
+  }, [initialUser, fetchedUser, isLoading])
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>
 }

--- a/src/app/mypage/context/UserContext.tsx
+++ b/src/app/mypage/context/UserContext.tsx
@@ -8,7 +8,7 @@ import {
   useEffect,
   useMemo,
 } from 'react'
-import { createClient } from '@/utils/supabase/client'
+import { getSupabaseClient } from '@/utils/supabase/client'
 
 interface User {
   id: string
@@ -31,21 +31,27 @@ interface UserContextType {
 
 const UserContext = createContext<UserContextType | undefined>(undefined)
 
-export function UserProvider({ children }: { children: ReactNode }) {
+export function UserProvider({
+  children,
+  initialUser,
+}: {
+  children: ReactNode
+  initialUser?: User | null
+}) {
   const [authState, setAuthState] = useState<UserContextType>({
-    user: null,
-    role: null,
-    isLoading: true,
+    user: initialUser ?? null,
+    role: (initialUser?.role as Role) ?? null,
+    isLoading: initialUser ? false : true,
   })
 
-  const supabase = createClient()
-
   useEffect(() => {
+    if (initialUser) return // 서버에서 이미 받았으면 스킵
+
+    const supabase = getSupabaseClient()
+
     const fetchFullUserData = async () => {
       try {
-        const {
-          data: { user: authUser },
-        } = await supabase.auth.getUser()
+        const { data: { user: authUser } } = await supabase.auth.getUser()
 
         if (!authUser) {
           setAuthState({ user: null, role: null, isLoading: false })
@@ -79,15 +85,19 @@ export function UserProvider({ children }: { children: ReactNode }) {
             role: profile.role as Role,
             isLoading: false,
           })
+        } else {
+          // 핵심 수정: profile이 null이어도 isLoading을 false로 변경
+          setAuthState({ user: null, role: null, isLoading: false })
         }
       } catch (error) {
         console.error('User fetch error:', error)
+        // catch에서도 isLoading: false 보장 (기존 유지)
         setAuthState((prev) => ({ ...prev, isLoading: false }))
       }
     }
 
     fetchFullUserData()
-  }, [supabase])
+  }, [initialUser]) // 마운트 시 1회만 실행
 
   const value = useMemo(() => authState, [authState])
 

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -8,35 +8,56 @@ interface LayoutProps {
   children: React.ReactNode
 }
 
-// (비동기) 서버 컴포넌트
 export default async function MyPageLayout({ children }: LayoutProps) {
-  
-  // 서버용 Supabase 클라이언트 생성
   const supabase = await createClient()
-  
-  // 인증된 사용자(user) 정보 가져오기
-  const { data: { user } } = await supabase.auth.getUser()
 
-  // public.users 테이블에서 role 포함된 프로필 정보 가져오기
-  const { data: profile } = user ? await supabase.from('users').select('id,email,name,role,grade,profile_image').eq('id', user.id).single() : { data: null }
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data: profile } = user
+    ? await supabase
+        .from('users')
+        .select('id,email,name,role,grade,profile_image')
+        .eq('id', user.id)
+        .single()
+    : { data: null }
+
+  // BUSINESS 유저일 경우 store 정보도 함께 조회
+  let storeData = null
+  if (profile?.role === 'BUSINESS') {
+    const { data } = await supabase
+      .from('stores')
+      .select('id, profile_image')
+      .eq('owner_id', profile.id)
+      .single()
+    storeData = data
+  }
+
+  const initialUser = profile
+    ? {
+        ...profile,
+        store_image: storeData?.profile_image ?? undefined,
+        store_id: storeData?.id ?? undefined,
+      }
+    : null
 
   return (
-    // 서버에서 조회한 사용자 정보를 initialUser로 전달
-    <UserProvider initialUser={profile}>
+    <UserProvider initialUser={initialUser}>
       <section className="min-h-screen w-full bg-[#FFF8F3] dark:bg-[#25292D] dark:text-black">
-      <div className="mx-auto flex max-w-6xl gap-6 px-4 pt-32">
-        <aside className="shrink-0">
-          <UserProfile />
-          <SideMenu />
-        </aside>
-        <main className="flex-1">
-          <div className="flex flex-col gap-6">
-            <SummaryMenu />
-          {children}
-          </div>
-        </main>
-      </div>
-    </section>
+        <div className="mx-auto flex max-w-6xl gap-6 px-4 pt-32">
+          <aside className="shrink-0">
+            <UserProfile />
+            <SideMenu />
+          </aside>
+          <main className="flex-1">
+            <div className="flex flex-col gap-6">
+              <SummaryMenu />
+              {children}
+            </div>
+          </main>
+        </div>
+      </section>
     </UserProvider>
   )
 }

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,21 +1,29 @@
-'use client'
-
-import SideMenu from './components/SideMenu'
+import { createClient } from '@/utils/supabase/server'
+import { UserProvider } from './context/UserContext'
 import SummaryMenu from './components/SummaryMenu'
 import UserProfile from './components/UserProfile'
-import { UserProvider, useUser } from './context/UserContext'
+import SideMenu from './components/SideMenu'
 
 interface LayoutProps {
   children: React.ReactNode
 }
 
-// 실제 내용을 그리는 내부 컴포넌트를 분리했습니다.
-// 이 안에서 role을 꺼내야 SummaryMenu에 key를 줄 수 있습니다.
-function LayoutContent({ children }: LayoutProps) {
-  const { role } = useUser()
+// (비동기) 서버 컴포넌트
+export default async function MyPageLayout({ children }: LayoutProps) {
+  
+  // 서버용 Supabase 클라이언트 생성
+  const supabase = await createClient()
+  
+  // 인증된 사용자(user) 정보 가져오기
+  const { data: { user } } = await supabase.auth.getUser()
+
+  // public.users 테이블에서 role 포함된 프로필 정보 가져오기
+  const { data: profile } = user ? await supabase.from('users').select('id,email,name,role,grade,profile_image').eq('id', user.id).single() : { data: null }
 
   return (
-    <section className="min-h-screen w-full bg-[#FFF8F3] dark:bg-[#25292D] dark:text-black">
+    // 서버에서 조회한 사용자 정보를 initialUser로 전달
+    <UserProvider initialUser={profile}>
+      <section className="min-h-screen w-full bg-[#FFF8F3] dark:bg-[#25292D] dark:text-black">
       <div className="mx-auto flex max-w-6xl gap-6 px-4 pt-32">
         <aside className="shrink-0">
           <UserProfile />
@@ -23,20 +31,12 @@ function LayoutContent({ children }: LayoutProps) {
         </aside>
         <main className="flex-1">
           <div className="flex flex-col gap-6">
-            {/* key를 제공함으로서 요약 메뉴가 변경되었음을 전달해 새로고침과 같이 새로 렌더링을 진행함  */}
-            <SummaryMenu key={role} />
+            <SummaryMenu />
           {children}
           </div>
         </main>
       </div>
     </section>
-  )
-}
-
-export default function MyPageLayout({ children }: LayoutProps) {
-  return (
-    <UserProvider>
-      <LayoutContent>{children}</LayoutContent>
     </UserProvider>
   )
 }

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,5 +1,16 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { createBrowserClient } from '@supabase/ssr'
 import { supabaseConfig } from './config'
 
 export const createClient = () =>
   createBrowserClient(supabaseConfig.url, supabaseConfig.key)
+
+
+// --------------------------------------------------------------------------
+// Supabase 싱글톤(Singleton)
+
+let singleton: SupabaseClient | null = null
+
+export const getSupabaseClient = () => {
+  return singleton ? singleton : (singleton = createClient())
+}


### PR DESCRIPTION
### **PR 유형**

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**
- 마이페이지 새로고침 시 스켈레톤 무한 로딩 현상 재현 및 해결 확인
- 판매자 계정 로그인 후 상점 정보(이미지, store_id) 정상 반영 확인
- 상단 쿠폰 메뉴 클릭 시 올바른 경로로 이동 확인

### **PR 상세**
무한로딩 발생 원인 
layout.tsx가 클라이언트 컴포넌트로 동작하면서 UserContext 내부의 useEffect에서 Supabase 비동기 호출이 완료되기 전까지 isLoading: true, user: null, role: null 상태로 렌더링이 시작됐습니다.
 이로 인해 SummaryMenu가 데이터 fetch를 중단하고 스켈레톤이 무한 노출되는 문제가 발생했습니다.

- layout.tsx를 서버 컴포넌트로 전환하여 유저 정보를 서버에서 미리 조회한 뒤 initialUser로 UserProvider에 전달, 페이지 진입 시 즉시 유저 상태가 반영되도록 수정했습니다.
- 판매자(BUSINESS) 계정의 경우 stores 테이블의 store_id와 store_image를 서버에서 함께 조회해 initialUser에 포함하도록 수정, 상점 프로필 이미지와 등록 상품 리스트가 정상 렌더링되지 않던 문제를 해결했습니다.
- 상단 네비게이션의 쿠폰 메뉴 클릭 시 잘못된 경로로 이동하던 버그를 수정했습니다.
- 개발 과정에서 사용한 테스트용 console.log 코드를 제거했습니다.

### **이슈번호 #201  **
