### PR TITLE
[FIX] 상품 status 미지정 시 stateStyles undefined 에러 수정

### DIFF
--- a/src/app/mypage/seller/products/components/SellerProductItemCard.tsx
+++ b/src/app/mypage/seller/products/components/SellerProductItemCard.tsx
@@ -15,7 +15,10 @@ export default function SellerProductItemCard({ product, onEdit }: CardProps) {
     HIDDEN: { label: '판매중단', stateStyles: 'bg-red-500 text-white' },
   }
 
-  const current = statusConfig[product.status as keyof typeof statusConfig]
+  const current = statusConfig[product.status as keyof typeof statusConfig] ?? {
+    label: '상태 미지정',
+    stateStyles: 'bg-gray-300 text-white',
+  }
 
   return (
     <div className="flex flex-row items-center gap-x-4 border-b border-gray-100 px-6 py-8 text-sm font-medium transition-colors hover:bg-gray-50">


### PR DESCRIPTION
### **PR 유형**

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**

- status 가 없을 경우에도 렌더링이 실패하지 않도록 변경 

### **PR 상세**

- 특정 계정의 상품 status 값이 ON_SALE, SOLD_OUT,  PREPARING, HIDDEN 이외의 값으로 DB에 저장되어 있어 statusConfig에서 undefined를 반환하고 stateStyles 접근 시 에러가 발생했습니다. ?? 연산자로 폴백 처리하여 알 수 없음으로 대체 출력하도록 수정했습니다.
- 
### **이슈번호 # **
