### PR TITLE
[REFACTOR] 260 마이페이지 상품 등록 내부 코드 리펙토링 

### DIFF
--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -55,7 +55,7 @@ export default function Modal({
       if (!isOpen || e.key !== 'Tab' || !dialogRef.current) return
 
       const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
       )
 
       if (focusableElements.length === 0) return
@@ -64,14 +64,18 @@ export default function Modal({
       const lastElement = focusableElements[focusableElements.length - 1]
 
       if (e.shiftKey) {
-        if (document.activeElement === firstElement || document.activeElement === titleRef.current || document.activeElement === dialogRef.current) {
-          lastElement.focus()
+        if (
+          document.activeElement === firstElement ||
+          document.activeElement === titleRef.current ||
+          document.activeElement === dialogRef.current
+        ) {
           e.preventDefault()
+          lastElement.focus()
         }
       } else {
         if (document.activeElement === lastElement) {
-          firstElement.focus()
           e.preventDefault()
+          dialogRef.current.focus()
         }
       }
     }
@@ -89,6 +93,7 @@ export default function Modal({
         onClick={onClose}
       />
       <section
+        tabIndex={0}
         ref={dialogRef}
         className="animate-in zoom-in-95 relative flex w-full max-w-200 flex-col overflow-hidden rounded-3xl bg-white shadow-[0_20px_50px_rgba(0,0,0,0.1)] duration-200"
         role="dialog"
@@ -115,7 +120,7 @@ export default function Modal({
         )}
         <button
           onClick={onClose}
-          className="absolute right-2 top-2 flex h-12 w-12 items-center justify-center rounded-full transition-all hover:bg-gray-50 active:scale-90 sm:right-4 sm:top-2 lg:right-8"
+          className="absolute top-2 right-2 flex h-12 w-12 items-center justify-center rounded-full transition-all hover:bg-gray-50 active:scale-90 sm:top-2 sm:right-4 lg:right-8"
           aria-label="닫기"
         >
           <X size={24} strokeWidth={2} className="text-[#333]" />

--- a/src/app/mypage/seller/register/components/CancelButton.tsx
+++ b/src/app/mypage/seller/register/components/CancelButton.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Modal from '@/app/components/Modal'
+import { ArrowLeft } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+type Props = {
+  isInputted: boolean
+  onConfirm: () => void
+}
+export default function CancelButton({ isInputted, onConfirm }: Props) {
+  const router = useRouter()
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleCancel = () => {
+    if (isInputted) {
+      setIsModalOpen(true)
+      return
+    }
+    router.push('/mypage/seller/products')
+  }
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleCancel}
+        className="flex items-center gap-3 bg-gray-400 p-3 font-semibold text-white hover:bg-red-500"
+      >
+        <ArrowLeft size={16} />
+        취소
+      </button>
+
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="상품 등록 취소"
+        footer={
+          <>
+            <button
+              onClick={() => setIsModalOpen(false)}
+              className="rounded-lg border px-4 py-2"
+            >
+              계속 작성
+            </button>
+            <button
+              onClick={() => {
+                onConfirm()
+                setIsModalOpen(false)
+                router.push('/mypage/seller/products')
+              }}
+              className="rounded-lg bg-black px-4 py-2 text-white"
+            >
+              취소하기
+            </button>
+          </>
+        }
+      >
+        <p>작성 중인 내용이 있습니다. 정말 취소하시겠습니까?</p>
+      </Modal>
+    </>
+  )
+}

--- a/src/app/mypage/seller/register/components/CategorySelector.tsx
+++ b/src/app/mypage/seller/register/components/CategorySelector.tsx
@@ -13,26 +13,7 @@ type Props = {
 
 export default function CategorySelector({ value, error, onChange }: Props) {
   const [selectedGroup, setSelectedGroup] = useState('')
-  const [selectedCategory, setSelectedCategory] = useState('')
-  const [prevValue, setPrevValue] = useState<string | undefined>(undefined)
-
-  if (value !== prevValue) {
-    setPrevValue(value)
-    if (value) {
-      const categoryName = Object.keys(CATEGORY_NAME_TO_ID).find(
-        (key) => CATEGORY_NAME_TO_ID[key] === value,
-      )
-      if (categoryName) {
-        const group = CATEGORY_GROUPS.find((g) =>
-          g.categories.includes(categoryName),
-        )
-        if (group) {
-          setSelectedGroup(group.label)
-          setSelectedCategory(value)
-        }
-      }
-    }
-  }
+  const selectedCategory = value ?? ''
 
   const currentGroup = CATEGORY_GROUPS.find(
     (group) => group.label === selectedGroup,
@@ -40,14 +21,11 @@ export default function CategorySelector({ value, error, onChange }: Props) {
 
   const handleGroupChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setSelectedGroup(e.target.value)
-    setSelectedCategory('')
     onChange('')
   }
 
   const handleCategoryChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const categoryId = e.target.value
-    setSelectedCategory(categoryId)
-    onChange(categoryId)
+    onChange(e.target.value)
   }
 
   return (
@@ -65,7 +43,7 @@ export default function CategorySelector({ value, error, onChange }: Props) {
         >
           <option value="">대분류 선택</option>
           {CATEGORY_GROUPS.map((g) => (
-            <option key={g.id} value={g.label}>
+            <option key={g.label} value={g.label}>
               {g.label}
             </option>
           ))}

--- a/src/app/mypage/seller/register/components/RegisterProduct.tsx
+++ b/src/app/mypage/seller/register/components/RegisterProduct.tsx
@@ -134,16 +134,6 @@ export default function RegisterProductForm() {
     })
   }
 
-  const handleInputChange = <T extends keyof ProductForm>(
-    name: T,
-    value: ProductForm[T],
-  ) => {
-    setForm((prev) => ({
-      ...prev,
-      [name]: value,
-    }))
-  }
-
   const getInputProps = (name: keyof ProductForm) => ({
     value: form[name] ?? '',
     onChange: (value: string) => {
@@ -209,7 +199,7 @@ export default function RegisterProductForm() {
             clientErrors.productCategoryId || serverErrors?.productCategoryId
           }
           onChange={(value) => {
-            handleInputChange('productCategoryId', value)
+            setForm((prev) => ({ ...prev, productCategoryId: value }))
             setClientErrors((prev) => ({ ...prev, productCategoryId: '' }))
           }}
         />

--- a/src/app/mypage/seller/register/components/RegisterProduct.tsx
+++ b/src/app/mypage/seller/register/components/RegisterProduct.tsx
@@ -17,6 +17,7 @@ import useOptionForm from '@/hooks/useOptionForm'
 import CategorySelector from './CategorySelector'
 import useRegisterImg from '../hooks/useRegisterImg'
 import { createClient } from '@/utils/supabase/client'
+import CancelButton from './CancelButton'
 
 type ProductErrors = {
   productImage?: string
@@ -28,6 +29,14 @@ type ProductErrors = {
   productOptions?: string
   productCategoryId?: string
 }
+const INITIAL_FORM = {
+  productName: '',
+  productPrice: '',
+  productDescription: '',
+  productInventory: '',
+  productDiscount: '',
+  productCategoryId: '',
+}
 
 export default function RegisterProductForm() {
   // 서버 액션
@@ -37,14 +46,7 @@ export default function RegisterProductForm() {
   )
   const [isPending, startTransition] = useTransition()
 
-  const [form, setForm] = useState<Partial<ProductForm>>({
-    productName: '',
-    productPrice: '',
-    productDescription: '',
-    productInventory: '',
-    productDiscount: '',
-    productCategoryId: '',
-  })
+  const [form, setForm] = useState<Partial<ProductForm>>(INITIAL_FORM)
   const serverErrors = formState?.errors
   const [clientErrors, setClientErrors] = useState<ProductErrors>({})
 
@@ -67,6 +69,15 @@ export default function RegisterProductForm() {
 
     return newErrors
   }
+
+  // 입력 폼 안에 작성한 부분이 있는지 검사
+  const isInputted =
+    Object.values(form).some((value) => value !== '') ||
+    imgForm.preview !== null ||
+    optionForm.state.options.length > 0
+
+  // 카테고리 리셋 상태 관리
+  const [categoryKey, setCategoryKey] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -133,18 +144,24 @@ export default function RegisterProductForm() {
     }))
   }
 
-  const handleBlur = <T extends keyof ProductForm>(name: T) => {
-    // form에서 해당 input의 현재 값을 가져오기
-    const value = form[name]
-    if (typeof value !== 'string') return
-    const error = validateProductForm(name, value)
-
-    // 해당 인푹의 에러만 업데이트 해서 보여줌
-    setClientErrors((prev) => ({
-      ...prev,
-      [name]: error,
-    }))
-  }
+  const getInputProps = (name: keyof ProductForm) => ({
+    value: form[name] ?? '',
+    onChange: (value: string) => {
+      setForm((prev) => ({ ...prev, [name]: value }))
+    },
+    onBlur: () => {
+      const value = form[name]
+      if (typeof value !== 'string') return
+      const error = validateProductForm(name, value)
+      setClientErrors((prev) => ({
+        ...prev,
+        [name]: error,
+      }))
+    },
+    error:
+      clientErrors[name as keyof ProductErrors] ||
+      serverErrors?.[name as keyof ProductErrors],
+  })
 
   return (
     <form
@@ -154,7 +171,19 @@ export default function RegisterProductForm() {
     >
       <div className="flex justify-between">
         <h2 className="text-2xl font-bold">상품 등록 페이지</h2>
-        <SubmitButton isPending={isPending} />
+        <div className="flex flex-row gap-3">
+          <CancelButton
+            isInputted={isInputted}
+            onConfirm={() => {
+              setForm(INITIAL_FORM)
+              imgForm.resetImg()
+              optionForm.actions.resetOptions()
+              setClientErrors({})
+              setCategoryKey((prev) => prev + 1)
+            }}
+          />
+          <SubmitButton isPending={isPending} />
+        </div>
       </div>
 
       <div className="flex flex-col gap-y-6">
@@ -168,41 +197,14 @@ export default function RegisterProductForm() {
           }}
           error={clientErrors.productImage || serverErrors?.productImage}
         />
-        <ProductName
-          value={form.productName ?? ''}
-          error={clientErrors.productName || serverErrors?.productName}
-          onChange={(value) => handleInputChange('productName', value)}
-          onBlur={() => handleBlur('productName')}
-        />
-        <ProductPrice
-          value={form.productPrice ?? ''}
-          error={clientErrors.productPrice || serverErrors?.productPrice}
-          onChange={(value) => handleInputChange('productPrice', value)}
-          onBlur={() => handleBlur('productPrice')}
-        />
-        <ProductDescription
-          value={form.productDescription ?? ''}
-          error={
-            clientErrors.productDescription || serverErrors?.productDescription
-          }
-          onChange={(value) => handleInputChange('productDescription', value)}
-          onBlur={() => handleBlur('productDescription')}
-        />
-        <ProductInventory
-          value={form.productInventory ?? ''}
-          error={
-            clientErrors.productInventory || serverErrors?.productInventory
-          }
-          onChange={(value) => handleInputChange('productInventory', value)}
-          onBlur={() => handleBlur('productInventory')}
-        />
-        <ProductDiscount
-          value={form.productDiscount ?? ''}
-          error={clientErrors.productDiscount || serverErrors?.productDiscount}
-          onChange={(value) => handleInputChange('productDiscount', value)}
-          onBlur={() => handleBlur('productDiscount')}
-        />
+        <ProductName {...getInputProps('productName')} />
+        <ProductPrice {...getInputProps('productPrice')} />
+        <ProductDescription {...getInputProps('productDescription')} />
+        <ProductInventory {...getInputProps('productInventory')} />
+        <ProductDiscount {...getInputProps('productDiscount')} />
         <CategorySelector
+          key={`category-${categoryKey}`}
+          value={form.productCategoryId}
           error={
             clientErrors.productCategoryId || serverErrors?.productCategoryId
           }

--- a/src/app/mypage/seller/register/lib/validateProductForm.ts
+++ b/src/app/mypage/seller/register/lib/validateProductForm.ts
@@ -4,13 +4,11 @@ export type Option = {
 }
 
 export type ProductForm = {
-  productImage: File | null
   productName: string
   productPrice: string
   productDescription: string
   productInventory: string
   productDiscount: string
-  productOptions: Option[]
   productCategoryId?: string
 }
 
@@ -33,8 +31,6 @@ const validators: Partial<
   productDescription: (value) => {
     const text = value.trim()
     if (!text) return '상품 정보를 입력하세요.'
-    if (!/^[가-힣a-zA-Z0-9\s\n.,!?~"'""''%]+$/.test(text))
-      return '한글 및 영문만 입력 가능합니다.'
     if (text.length < 10) return '최소 10자 이상 입력해야 합니다.'
     if (text.length > 500) return '최대 500자까지 입력 가능합니다.'
     return ''

--- a/src/hooks/useOptionForm.ts
+++ b/src/hooks/useOptionForm.ts
@@ -70,6 +70,13 @@ export default function useOptionForm(
     setOptionValue(value)
   }
 
+  const resetOptions = () => {
+    setOptionType('')
+    setOptionValue('')
+    setOptions([])
+    setError('')
+  }
+
   return {
     state: {
       optionType,
@@ -84,6 +91,7 @@ export default function useOptionForm(
       handleInput,
       setOptions,
       setError,
+      resetOptions,
     },
   }
 }


### PR DESCRIPTION
### PR 유형

 새로운 기능 추가

- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

### PR 체크리스트

- 상품 등록 폼 취소 시 모든 필드(텍스트, 이미지, 옵션, 카테고리) 초기화 확인
- 모달 포커스 트랩 정상 동작 확인
- 카테고리 선택기 리셋 정상 동작 확인

### PR 상세

- 미사용 패키지(three.js 등) 제거로 번들 크기 약 600KB 감소
- RegisterProductForm에 INITIAL_FORM 상수 추가 및 취소 시 전체 폼 리셋 처리
- handleInputChange, handleBlur 제거 후 getInputProps로 통합 리팩토링
- CategorySelector 내부 상태 관리 방식을 useEffect → 직접 계산 방식으로 변경 (불필요한 상태 제거)
- CancelButton 컴포넌트 분리 및 모달 연동, 입력값 있을 때만 확인 모달 노출
- useOptionForm에 resetOptions 함수 추가
- 모달 포커스 트랩 e.preventDefault() 순서 수정 및 section에 tabIndex={0} 추가

**이슈번호 #260 **