### PR TITLE
[FIX] 272 판매자 회원가입 시 상점 생성 및 상품 등록 방어 로직 추가

### DIFF
--- a/src/actions/signupAction.ts
+++ b/src/actions/signupAction.ts
@@ -72,6 +72,12 @@ export const signupAction = async (
       confirmPassword: confirmPassword,
       role: role,
     }
+  if (role === 'BUSINESS') {
+    await supabase.from('stores').insert({
+      owner_id: data.user?.id,
+      name: `${name}님의 가게`, // 기본 가게명
+    })
+  }
 
   redirect('/signup/signup-result')
 }

--- a/src/app/mypage/seller/register/actions/registerProduct.ts
+++ b/src/app/mypage/seller/register/actions/registerProduct.ts
@@ -101,6 +101,15 @@ async function processRegister(formData: FormData): Promise<FormState> {
     .eq('owner_id', user?.id)
     .single()
 
+  if (!store) {
+    return {
+      errors: {
+        productName:
+          '상점 정보가 저장되지 않았습니다. 상점 정보 관리를 통해 정보를 등록해주세요.',
+      },
+    }
+  }
+
   const publicUrl = formData.get('thumbnailUrl')?.toString()
   if (!publicUrl) {
     errors.productImage = '이미지를 업로드해야 합니다.'


### PR DESCRIPTION
### **PR 유형**

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**

- 회원가입 시 판매자 상점 등록
- 상점 정보 부재 시 상품 등록이 불가능하도록 2차 방어 로직 작성

### **PR 상세**

기존 문제 상황: 판매자 회원가입 시 stores 테이블에 row가 자동 생성되지 않아, 마이페이지에서 상점 정보를 수동 저장하기 전까지 store_id가 null로 유지되는 현상이 있었습니다. 이로 인해 상품 등록은 성공하나, DB 내에서 정상적인 상점 기준 조회가 불가능한 데이터 정합성 문제가 발생했습니다.

해결 방안: 위의 데이터 무결성 문제를 해결하기 위해 회원가입 및 상품 등록 단계에 이중 방어 로직을 구축했습니다.

- 회원가입 로직 수정 (signupAction.ts): 판매자 회원가입 즉시 stores 테이블에 상점 레코드가 바로 insert 되도록 수정했습니다. (현재 회원가입 시점에 구체적인 상점 정보를 받지 않으므로, 초기 상점명은 ${name}님의 가게로 임시 설정해두었습니다.)

- 상품 등록 가드 추가 (registerProduct.ts): 상품 등록 인서트 직전에 한 번 더 유저의 상점 정보 존재 여부를 검증하고, 상점 정보가 없을 경우 등록 프로세스를 원천 차단한 뒤 안전하게 에러를 반환하도록 방어했습니다.  

### **이슈번호 #272  **
