### PR TITLE
[FEAT] 274 마이페이지 상품 삭제 추가 

### DIFF
--- a/src/app/mypage/seller/products/components/SellerProductItemCard.tsx
+++ b/src/app/mypage/seller/products/components/SellerProductItemCard.tsx
@@ -5,9 +5,14 @@ import { DiscountPriceFormat } from '@/utils/intl'
 interface CardProps {
   product: SellerProduct
   onEdit: () => void
+  onDelete: () => void
 }
 
-export default function SellerProductItemCard({ product, onEdit }: CardProps) {
+export default function SellerProductItemCard({
+  product,
+  onEdit,
+  onDelete,
+}: CardProps) {
   const statusConfig = {
     ON_SALE: { label: '판매중', stateStyles: 'bg-[#00C37E] text-white' },
     SOLD_OUT: { label: '품절', stateStyles: 'bg-gray-400 text-white' },
@@ -58,12 +63,20 @@ export default function SellerProductItemCard({ product, onEdit }: CardProps) {
         {product.inventory.toLocaleString()}
       </p>
 
-      <button
-        onClick={onEdit}
-        className="h-9 w-16 shrink-0 rounded-md border border-gray-300 text-xs font-semibold text-gray-600 transition-colors hover:bg-gray-100"
-      >
-        관리
-      </button>
+      <div className="flex shrink-0 gap-2">
+        <button
+          onClick={onEdit}
+          className="h-9 w-16 rounded-md border border-gray-300 text-xs font-semibold text-gray-600 transition-colors hover:bg-gray-100"
+        >
+          관리
+        </button>
+        <button
+          onClick={onDelete}
+          className="h-9 w-16 rounded-md border border-red-300 text-xs font-semibold text-red-500 transition-colors hover:bg-red-50"
+        >
+          삭제
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/app/mypage/seller/products/components/SellerProductItemList.tsx
+++ b/src/app/mypage/seller/products/components/SellerProductItemList.tsx
@@ -21,6 +21,7 @@ export default function SellerProductItemList() {
   const [selectedProduct, setSelectedProduct] = useState<SellerProduct | null>(
     null,
   )
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
 
   const { user, isLoading: isUserLoading } = useUser()
   const storeId = (user as unknown as CustomUser)?.store_id
@@ -29,6 +30,7 @@ export default function SellerProductItemList() {
     products,
     isLoading: isDataLoading,
     refetch,
+    deleteProduct,
   } = useSellerProducts(storeId)
 
   const itemsPerPage = 5
@@ -57,6 +59,7 @@ export default function SellerProductItemList() {
                 <SellerProductItemCard
                   product={product}
                   onEdit={() => setSelectedProduct(product)}
+                  onDelete={() => setDeleteTargetId(product.id)}
                 />
               </li>
             ))}
@@ -78,6 +81,31 @@ export default function SellerProductItemList() {
             refetch()
           }}
         />
+      )}
+
+      {deleteTargetId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="rounded-lg bg-white p-6 shadow-lg">
+            <p className="mb-4 text-sm font-medium">정말 삭제하시겠습니까?</p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setDeleteTargetId(null)}
+                className="rounded-md border px-4 py-2 text-sm"
+              >
+                취소
+              </button>
+              <button
+                onClick={async () => {
+                  await deleteProduct(deleteTargetId)
+                  setDeleteTargetId(null)
+                }}
+                className="rounded-md bg-red-500 px-4 py-2 text-sm text-white"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/app/mypage/seller/products/hooks/useSellerProducts.ts
+++ b/src/app/mypage/seller/products/hooks/useSellerProducts.ts
@@ -30,6 +30,30 @@ export const useSellerProducts = (storeId: string | undefined) => {
     }
   }, [])
 
+  const deleteProduct = useCallback(async (productId: string) => {
+    try {
+      const supabase = createClient()
+
+      // product_categories 먼저 삭제 (FK 제약 때문에 순서 중요!)
+      await supabase
+        .from('product_categories')
+        .delete()
+        .eq('product_id', productId)
+
+      const { error } = await supabase
+        .from('products')
+        .delete()
+        .eq('id', productId)
+
+      if (error) throw error
+
+      // 삭제 후 목록에서 바로 제거 (refetch 없이 즉시 반영)
+      setProducts((prev) => prev.filter((p) => p.id !== productId))
+    } catch (err) {
+      console.error('Error deleting product:', err)
+    }
+  }, [])
+
   useEffect(() => {
     if (!storeId) {
       const timer = setTimeout(() => setIsLoading(false), 0)
@@ -47,5 +71,6 @@ export const useSellerProducts = (storeId: string | undefined) => {
     products,
     isLoading,
     refetch: () => storeId && fetchProducts(storeId),
+    deleteProduct,
   }
 }

--- a/src/app/mypage/types/sellerOrderItems.ts
+++ b/src/app/mypage/types/sellerOrderItems.ts
@@ -1,8 +1,8 @@
 import { ProductOptionType } from '@/app/lib/products.types'
 
 export interface SellerProduct {
-  id: number
-  store_id: number
+  id: string
+  store_id: string
   name: string
   thumbnail_image: string
   content?: string


### PR DESCRIPTION
### **PR 유형**

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**

- 마이페이지 상품 관리 페이지에서 상품 관리 뿐만 아니라 삭제도 가능하도록 버튼 및 로직 추가 

### **PR 상세**
- SellerProduct 인터페이스의 id, store_id가 number로 잘못 지정되어 있던 부분을 실제 DB UUID 형식에 맞게 string으로 수정했습니다.
- SellerProductItemCard에 기존 관리 버튼 옆에 삭제 버튼을 추가했습니다.
- 삭제 버튼 클릭 시 실수로 삭제하는 것을 방지하기 위해 "정말 삭제하시겠습니까?" 확인 모달이 노출됩니다.
- 모달에서 취소 클릭 시 삭제가 취소되고, 삭제 클릭 시 삭제가 진행됩니다.
- 삭제 확인 시 FK 제약 조건으로 인해 product_categories를 먼저 삭제 후 products 테이블에서 해당 상품을 삭제합니다.
- DB 삭제 완료 후 별도 refetch 없이 목록에서 즉시 제거되도록 구현했습니다.

- Tab으로 이동 시 모달 외부로 포커스가 이동하는 문제 (포커스 트랩 미적용)
  → 관리 모달 포커스 트랩 적용 시 함께 수정 예정입니다. 

<img width="556" height="584" alt="image" src="https://github.com/user-attachments/assets/7e12ed9a-9de2-4028-b3ce-1455ddebed9c" />
<img width="553" height="627" alt="image" src="https://github.com/user-attachments/assets/66dfb500-f9d5-47d2-aaa7-187528625d11" />


### **이슈번호 #274  **
