### PR TITLE
[REFACTOR] 277 공통 모달 컴포넌트로 교체 

### DIFF
--- a/src/app/mypage/seller/products/components/ProductEditModal.tsx
+++ b/src/app/mypage/seller/products/components/ProductEditModal.tsx
@@ -1,37 +1,27 @@
 'use client'
 
 import { SellerProduct } from '@/app/mypage/types/sellerOrderItems'
-
 import { ProductFormField } from './ProductFormField'
-
 import { useProductEdit } from '@/hooks/useProductEdit'
-
 import CategorySelector from '../../register/components/CategorySelector'
-
 import OptionInput from '../../register/components/OptionInput'
-
 import ImageUploader from '@/app/mypage/consumer/profile/components/ImageUploader'
+import Modal from '@/app/components/Modal'
 
 interface Props {
   product: SellerProduct
-
   onClose: () => void
 }
 
 export default function ProductEditModal({ product, onClose }: Props) {
   const {
     formData,
-
+    isCategoryLoaded,
     errors,
-
     handleChange,
-
     handleSubmit,
-
     finalPrice,
-
     optionForm,
-
     clearOptionError,
   } = useProductEdit(product, onClose)
 
@@ -39,47 +29,46 @@ export default function ProductEditModal({ product, onClose }: Props) {
     'w-full border border-[#D1D5DC] bg-[#F9FAFB] px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="flex max-h-[95vh] w-full max-w-[800px] flex-col overflow-hidden rounded-md bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-gray-200 px-8 py-6">
-          <h2 className="text-xl font-bold text-gray-900">상품 정보 수정</h2>
-
-          <button onClick={onClose} className="text-gray-400 hover:text-black">
-            <svg
-              className="h-6 w-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      title="상품 정보 수정"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 border border-[#D1D5DC] py-4 text-sm font-semibold text-gray-500 transition-all hover:bg-gray-50"
+          >
+            취소
           </button>
-        </div>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="flex-1 bg-black py-4 text-sm font-semibold text-white shadow-md transition-all hover:bg-gray-800 active:scale-[0.98]"
+          >
+            정보 수정 완료
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-10">
+        <section>
+          <label className="mb-3 block text-sm font-medium">상품 이미지</label>
+          <div className="rounded-md border border-[#D1D5DC] bg-[#F9FAFB] p-6">
+            <ImageUploader
+              key={product.id}
+              label=""
+              defaultImage={product.thumbnail_image}
+              isEditing={true}
+            />
+          </div>
+        </section>
 
-        <div className="flex-1 space-y-10 overflow-y-auto px-8 py-8">
-          <section>
-            <label className="mb-3 block text-sm font-medium">
-              상품 이미지
-            </label>
-
-            <div className="rounded-md border border-[#D1D5DC] bg-[#F9FAFB] p-6">
-              <ImageUploader
-                key={product.id}
-                label=""
-                defaultImage={product.thumbnail_image}
-                isEditing={true}
-              />
-            </div>
-          </section>
-
-          <section>
-            <ProductFormField label="카테고리 설정" error={errors.category}>
-              <div className="mt-2">
+        <section>
+          <ProductFormField label="카테고리 설정" error={errors.category}>
+            <div className="mt-2">
+              {isCategoryLoaded ? (
                 <CategorySelector
                   value={formData.category}
                   onChange={(categoryId) => {
@@ -90,133 +79,111 @@ export default function ProductEditModal({ product, onClose }: Props) {
                     >)
                   }}
                 />
-              </div>
-            </ProductFormField>
-          </section>
+              ) : (
+                <div className="h-10 w-48 animate-pulse rounded-md bg-gray-100" />
+              )}
+            </div>
+          </ProductFormField>
+        </section>
 
-          <section>
-            <ProductFormField label="옵션 설정" error={errors.options}>
-              <div onClick={clearOptionError}>
-                <OptionInput optionForm={optionForm} />
-              </div>
-            </ProductFormField>
-          </section>
+        <section>
+          <ProductFormField label="옵션 설정" error={errors.options}>
+            <div onClick={clearOptionError}>
+              <OptionInput optionForm={optionForm} />
+            </div>
+          </ProductFormField>
+        </section>
 
-          <section className="grid grid-cols-2 gap-6">
-            <ProductFormField label="판매 상태" error={errors.status}>
-              <div className="relative mt-2">
-                <select
-                  name="status"
-                  value={formData.status}
-                  onChange={handleChange}
-                  className={`${inputStyle} cursor-pointer appearance-none`}
+        <section className="grid grid-cols-2 gap-6">
+          <ProductFormField label="판매 상태" error={errors.status}>
+            <div className="relative mt-2">
+              <select
+                name="status"
+                value={formData.status}
+                onChange={handleChange}
+                className={`${inputStyle} cursor-pointer appearance-none`}
+              >
+                <option value="ON_SALE">판매중</option>
+                <option value="SOLD_OUT">품절</option>
+                <option value="HIDDEN">판매중지</option>
+                <option value="PREPARING">준비중</option>
+              </select>
+              <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-gray-500">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
                 >
-                  <option value="ON_SALE">판매중</option>
-
-                  <option value="SOLD_OUT">품절</option>
-
-                  <option value="HIDDEN">판매중지</option>
-
-                  <option value="PREPARING">준비중</option>
-                </select>
-
-                <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-gray-500">
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </div>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
               </div>
-            </ProductFormField>
-
-            <ProductFormField label="재고 수량" error={errors.inventory}>
-              <div className="mt-2">
-                <input
-                  type="number"
-                  name="inventory"
-                  value={formData.inventory === 0 ? '' : formData.inventory}
-                  onChange={handleChange}
-                  className={inputStyle}
-                  placeholder="0"
-                />
-              </div>
-            </ProductFormField>
-
-            <ProductFormField label="원가 (원)" error={errors.price}>
-              <div className="mt-2">
-                <input
-                  type="number"
-                  name="price"
-                  value={formData.price === 0 ? '' : formData.price}
-                  onChange={handleChange}
-                  className={inputStyle}
-                  placeholder="가격을 입력하세요"
-                />
-              </div>
-            </ProductFormField>
-
-            <ProductFormField label="할인율 (%)" error={errors.discount_rate}>
-              <div className="mt-2">
-                <input
-                  type="number"
-                  name="discount_rate"
-                  value={
-                    formData.discount_rate === 0 ? '' : formData.discount_rate
-                  }
-                  onChange={handleChange}
-                  className={inputStyle}
-                  placeholder="0"
-                />
-              </div>
-            </ProductFormField>
-          </section>
-
-          <section className="flex items-center justify-between rounded-md border border-[#D1D5DC] bg-gray-50 p-6">
-            <div className="flex flex-col gap-1">
-              <span className="text-[10px] font-bold tracking-wider text-gray-400 uppercase">
-                최종 판매가
-              </span>
-
-              <p className="text-xs text-gray-400 line-through">
-                {formData.price.toLocaleString()}원
-              </p>
             </div>
+          </ProductFormField>
 
-            <div className="text-right">
-              <span className="text-2xl font-bold text-black">
-                {finalPrice.toLocaleString()}원
-              </span>
+          <ProductFormField label="재고 수량" error={errors.inventory}>
+            <div className="mt-2">
+              <input
+                type="number"
+                name="inventory"
+                value={formData.inventory === 0 ? '' : formData.inventory}
+                onChange={handleChange}
+                className={inputStyle}
+                placeholder="0"
+              />
             </div>
-          </section>
-        </div>
+          </ProductFormField>
 
-        <div className="flex gap-3 border-t border-gray-200 bg-white px-8 py-6">
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex-1 border border-[#D1D5DC] py-4 text-sm font-semibold text-gray-500 transition-all hover:bg-gray-50"
-          >
-            취소
-          </button>
+          <ProductFormField label="원가 (원)" error={errors.price}>
+            <div className="mt-2">
+              <input
+                type="number"
+                name="price"
+                value={formData.price === 0 ? '' : formData.price}
+                onChange={handleChange}
+                className={inputStyle}
+                placeholder="가격을 입력하세요"
+              />
+            </div>
+          </ProductFormField>
 
-          <button
-            type="button"
-            onClick={handleSubmit}
-            className="flex-1 bg-black py-4 text-sm font-semibold text-white shadow-md transition-all hover:bg-gray-800 active:scale-[0.98]"
-          >
-            정보 수정 완료
-          </button>
-        </div>
+          <ProductFormField label="할인율 (%)" error={errors.discount_rate}>
+            <div className="mt-2">
+              <input
+                type="number"
+                name="discount_rate"
+                value={
+                  formData.discount_rate === 0 ? '' : formData.discount_rate
+                }
+                onChange={handleChange}
+                className={inputStyle}
+                placeholder="0"
+              />
+            </div>
+          </ProductFormField>
+        </section>
+
+        <section className="flex items-center justify-between rounded-md border border-[#D1D5DC] bg-gray-50 p-6">
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] font-bold tracking-wider text-gray-400 uppercase">
+              최종 판매가
+            </span>
+            <p className="text-xs text-gray-400 line-through">
+              {formData.price.toLocaleString()}원
+            </p>
+          </div>
+          <div className="text-right">
+            <span className="text-2xl font-bold text-black">
+              {finalPrice.toLocaleString()}원
+            </span>
+          </div>
+        </section>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/src/app/mypage/seller/products/components/SellerProductItemList.tsx
+++ b/src/app/mypage/seller/products/components/SellerProductItemList.tsx
@@ -9,6 +9,7 @@ import ProductEditModal from './ProductEditModal'
 import { useSellerProducts } from '../hooks/useSellerProducts'
 import Pagination from '@/app/components/Pagination'
 import { useProductFilter } from '@/hooks/useFiltering'
+import Modal from '@/app/components/Modal'
 
 interface CustomUser {
   id: string
@@ -83,30 +84,32 @@ export default function SellerProductItemList() {
         />
       )}
 
-      {deleteTargetId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="rounded-lg bg-white p-6 shadow-lg">
-            <p className="mb-4 text-sm font-medium">정말 삭제하시겠습니까?</p>
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setDeleteTargetId(null)}
-                className="rounded-md border px-4 py-2 text-sm"
-              >
-                취소
-              </button>
-              <button
-                onClick={async () => {
-                  await deleteProduct(deleteTargetId)
-                  setDeleteTargetId(null)
-                }}
-                className="rounded-md bg-red-500 px-4 py-2 text-sm text-white"
-              >
-                삭제
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <Modal
+        isOpen={!!deleteTargetId}
+        onClose={() => setDeleteTargetId(null)}
+        title="상품 삭제"
+        footer={
+          <>
+            <button
+              onClick={() => setDeleteTargetId(null)}
+              className="rounded-md border px-4 py-2 text-sm"
+            >
+              취소
+            </button>
+            <button
+              onClick={async () => {
+                await deleteProduct(deleteTargetId!)
+                setDeleteTargetId(null)
+              }}
+              className="rounded-md bg-red-500 px-4 py-2 text-sm text-white"
+            >
+              삭제
+            </button>
+          </>
+        }
+      >
+        <p className="text-sm text-gray-600">정말 삭제하시겠습니까?</p>
+      </Modal>
     </div>
   )
 }

--- a/src/app/mypage/seller/register/components/CategorySelector.tsx
+++ b/src/app/mypage/seller/register/components/CategorySelector.tsx
@@ -11,8 +11,22 @@ type Props = {
   onChange: (value: string) => void
 }
 
+const findInitialGroup = (categoryId: string) => {
+  if (!categoryId) return ''
+  for (const group of CATEGORY_GROUPS) {
+    for (const categoryName of group.categories) {
+      if (CATEGORY_NAME_TO_ID[categoryName] === categoryId) {
+        return group.label
+      }
+    }
+  }
+  return ''
+}
+
 export default function CategorySelector({ value, error, onChange }: Props) {
-  const [selectedGroup, setSelectedGroup] = useState('')
+  const [selectedGroup, setSelectedGroup] = useState(() =>
+    findInitialGroup(value ?? ''),
+  )
   const selectedCategory = value ?? ''
 
   const currentGroup = CATEGORY_GROUPS.find(

--- a/src/hooks/useProductEdit.ts
+++ b/src/hooks/useProductEdit.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import { SellerProduct } from '@/app/mypage/types/sellerOrderItems'
 import { productUpdateSchema } from '@/app/mypage/types/productSchema'
-import useOptionForm from './useOptionForm'
+import useOptionForm from '@/hooks/useOptionForm'
 
 export const useProductEdit = (product: SellerProduct, onClose: () => void) => {
   const supabase = createClient()
@@ -15,10 +15,10 @@ export const useProductEdit = (product: SellerProduct, onClose: () => void) => {
     category: '',
   })
 
+  const [isCategoryLoaded, setIsCategoryLoaded] = useState(false)
   const optionForm = useOptionForm(product.options || [])
   const { setOptions } = optionForm.actions
   const [errors, setErrors] = useState<Record<string, string>>({})
-
   const isInitialized = useRef(false)
 
   useEffect(() => {
@@ -48,6 +48,7 @@ export const useProductEdit = (product: SellerProduct, onClose: () => void) => {
       }
 
       isInitialized.current = true
+      setIsCategoryLoaded(true)
     }
 
     initializeData()
@@ -95,7 +96,6 @@ export const useProductEdit = (product: SellerProduct, onClose: () => void) => {
     }
 
     try {
-      // 상품 정보 업데이트
       const { error: productUpdateError } = await supabase
         .from('products')
         .update({
@@ -109,7 +109,6 @@ export const useProductEdit = (product: SellerProduct, onClose: () => void) => {
 
       if (productUpdateError) throw productUpdateError
 
-      //카테고리 정보 업데이트
       const { error: categoryUpdateError } = await supabase
         .from('product_categories')
         .upsert(
@@ -137,6 +136,7 @@ export const useProductEdit = (product: SellerProduct, onClose: () => void) => {
 
   return {
     formData,
+    isCategoryLoaded,
     errors,
     handleChange,
     handleSubmit,


### PR DESCRIPTION
### **PR 유형**

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**

- 공통 모달 컴포넌트 교체
- 상품 관리 내에서 기존에 등록된 카테고리 불러오기  

### **PR 상세**
### 1. useProductEdit.ts — isCategoryLoaded 플래그 추가
수정 이유
기존에는 모달이 열리자마자 CategorySelector가 바로 마운트됐습니다. 그런데 카테고리 데이터는 DB에서 비동기로 가져오기 때문에, CategorySelector가 마운트되는 시점에는 카테고리 값이 아직 빈값('')인 상태였습니다.

```
// 추가 전
useEffect(() => {
  const initializeData = async () => {
    const { data } = await supabase
      .from('product_categories')
      .select('category_id')
      ...
    setFormData((prev) => ({ ...prev, category: data.category_id }))
    // 여기서 category가 채워지지만 CategorySelector는 이미 빈값으로 마운트된 상태
  }
})
```
```
// 추가 후
const [isCategoryLoaded, setIsCategoryLoaded] = useState(false)

useEffect(() => {
  const initializeData = async () => {
    const { data } = await supabase
      .from('product_categories')
      .select('category_id')
      ...
    setFormData((prev) => ({ ...prev, category: data.category_id }))
    setIsCategoryLoaded(true)  // ← DB 로딩 완료 시점을 명시적으로 표시
  }
})
```
isCategoryLoaded가 false인 동안은 CategorySelector 대신 스켈레톤(로딩 UI)을 보여주고, true가 되는 순간 CategorySelector를 마운트합니다. 이렇게 하면 CategorySelector가 마운트되는 시점에 카테고리 값이 이미 준비된 상태가 보장됩니다.

---
### 2. CategorySelector.tsx — findInitialGroup 함수 추가
CategorySelector는 대분류(selectedGroup)와 소분류(value) 두 단계로 나뉘는데, DB에는 소분류의 카테고리 ID만 저장됩니다. 따라서 카테고리 ID만 가지고 있을 때 어떤 대분류에 속하는지 알아야 소분류 목록을 보여줄 수 있습니다.

```
// 추가 전
// 그냥 빈값으로 시작 → 대분류를 알 수 없어서 소분류 목록 자체가 안 보임
const [selectedGroup, setSelectedGroup] = useState('')
```
```
// 추가 후
// 카테고리 ID로 대분류를 거꾸로 탐색하는 함수
const findInitialGroup = (categoryId: string) => {
  if (!categoryId) return ''
  for (const group of CATEGORY_GROUPS) {           // 모든 대분류를 순회
    for (const categoryName of group.categories) { // 각 대분류의 소분류 목록을 순회
      if (CATEGORY_NAME_TO_ID[categoryName] === categoryId) {
        return group.label  // ID가 일치하는 소분류를 찾으면 해당 대분류명 반환
      }
    }
  }
  return 
}
// 마운트 시점에 findInitialGroup으로 대분류를 찾아서 초기값으로 설정
const [selectedGroup, setSelectedGroup] = useState(
  () => findInitialGroup(value ?? '')
  // value = 'c1100000-...' → '필기구' 반환 → selectedGroup = '필기구'
  // value = '' → '' 반환 → selectedGroup = '' (신규 등록 시)
)
```
useState는 컴포넌트가 처음 마운트될 때 딱 한 번만 초기값을 계산합니다. useProductEdit에서 isCategoryLoaded로 마운트 시점을 카테고리 로딩 완료 이후로 미뤘기 때문에, 마운트 시점에 value에 이미 카테고리 ID가 담겨 있어서 findInitialGroup이 올바른 대분류를 찾아줄 수 있습니다.

---
### 3. ProductEditModal.tsx — 공통 Modal 컴포넌트 교체 및 isCategoryLoaded 연결
수정 이유 1 - 공통 Modal 컴포넌트 교체
기존 모달은 포커스 트랩, ESC 닫기, 배경 스크롤 방지 등 접근성 기능이 없었습니다. 공통 Modal.tsx 컴포넌트에는 이 기능들이 이미 구현되어 있어 공통 컴포넌트로 교체했습니다. 

수정 이유 2 - isCategoryLoaded 연결
useProductEdit에서 받아온 isCategoryLoaded를 활용해서 카테고리 로딩 완료 전후를 구분합니다.
```
// 추가 전
// 카테고리 로딩 여부와 관계없이 항상 CategorySelector 렌더링
<CategorySelector
  value={formData.category}  // 빈값일 수도 있음
  onChange={...}
/>
```
```
// 추가 후
// isCategoryLoaded가 true일 때만 CategorySelector 마운트
{isCategoryLoaded ? (
  <CategorySelector
    value={formData.category}  // 항상 카테고리 ID가 담겨있음이 보장됨
    onChange={...}
  />
) : (
  // 로딩 중에는 스켈레톤 표시
  <div className="h-10 w-48 animate-pulse rounded-md bg-gray-100" />
)}
```

### **이슈번호 #277  **
