### PR TITLE
[STYLE] 279 상품 관리 레이아웃 수정 

### DIFF
--- a/src/app/mypage/seller/products/components/SellerProductItemCard.tsx
+++ b/src/app/mypage/seller/products/components/SellerProductItemCard.tsx
@@ -28,7 +28,16 @@ export default function SellerProductItemCard({
     product.name.length > 18 ? `${product.name.slice(0, 18)}...` : product.name
 
   return (
-    <div className="flex flex-col items-center border-b border-gray-100 text-sm font-medium transition-colors hover:bg-gray-50 md:gap-x-4 md:px-6 md:py-8 lg:grid lg:grid-cols-[4fr_1fr_1fr_1fr_1fr_72px]">
+    <div className="flex flex-col items-center border-b border-gray-100 text-sm font-medium transition-colors hover:bg-gray-50 md:gap-x-4 md:px-6 md:py-8 lg:grid lg:grid-cols-[80px_2fr_1fr_1fr_1fr_1fr_120px]">
+      {/* 상태 뱃지 - lg에서만 별도 컬럼으로 표시 */}
+      <div className="hidden lg:flex lg:justify-center">
+        <span
+          className={`shrink-0 rounded-sm px-2 py-0.5 text-[10px] ${current.stateStyles}`}
+        >
+          {current.label}
+        </span>
+      </div>
+
       <div className="flex h-full w-full min-w-0 flex-col items-center gap-4">
         <div className="relative h-50 w-50 shrink-0 overflow-hidden rounded-sm bg-gray-100 md:h-20 md:w-20">
           <Image
@@ -44,7 +53,7 @@ export default function SellerProductItemCard({
         </div>
         <div className="flex min-w-0 flex-1 items-center gap-2 md:overflow-hidden">
           <span
-            className={`shrink-0 rounded-sm px-2 py-0.5 text-[10px] ${current.stateStyles}`}
+            className={`shrink-0 rounded-sm px-2 py-0.5 text-[10px] lg:hidden ${current.stateStyles}`}
           >
             {current.label}
           </span>
@@ -68,6 +77,7 @@ export default function SellerProductItemCard({
           </button>
         </div>
       </div>
+
       <div className="flex flex-row justify-between gap-3 lg:contents">
         <span className="w-16 text-left text-gray-500 lg:hidden">판매가</span>
         <p className="text-gray-500 md:text-center">

--- a/src/app/mypage/seller/products/components/SellerProductItemHeader.tsx
+++ b/src/app/mypage/seller/products/components/SellerProductItemHeader.tsx
@@ -1,11 +1,13 @@
 export default function SellerProductItemHeader() {
   return (
-    <div className="hidden border-b border-gray-200 bg-gray-50/50 px-6 py-4 text-sm font-bold text-gray-600 md:grid md:grid-cols-[4fr_1fr_1fr_1fr_1fr_72px] md:gap-x-3">
-      <div>상품명</div>
+    <div className="hidden border-b border-gray-200 bg-gray-50/50 px-6 py-4 text-sm font-bold text-gray-600 md:grid md:grid-cols-[4fr_1fr_1fr_1fr_1fr_72px] md:gap-x-3 lg:grid lg:grid-cols-[80px_2fr_1fr_1fr_1fr_1fr_120px] lg:gap-x-3">
+      <div className="text-center">상태</div>
+      <div className="text-center">상품 정보</div>
       <div className="text-center">원가</div>
       <div className="text-center">총 가격</div>
       <div className="text-center">할인율</div>
       <div className="text-center">재고</div>
+      <div />
     </div>
   )
 }


### PR DESCRIPTION
### **PR 유형**

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### **PR 체크리스트**
- 상품 관리 레이아웃 수정 

### **PR 상세**
- 데스크탑의 경우 기존 디자인이 뱃지에 의해 울퉁불퉁하게 보이는 부분이 있어 해당 부분의 레이아웃을 수정했습니다. 
- 기존의 상품명 부분에서 상태와 상품 정보를 전부 나타내고 있던 부분을 분리했습니다. 
- 상태 컬럼은 데스크탑일 경우에만 보이고 모바일의 경우에는 기존의 디자인과 동일하게 상품 상태와 상품명이 같이 나타나는 레이아웃입니다. 

변경 전 
<img width="586" height="451" alt="image" src="https://github.com/user-attachments/assets/19237245-a8af-470d-a6c5-c0d775092ffd" />
변경 후 
<img width="552" height="432" alt="image" src="https://github.com/user-attachments/assets/264507c3-baec-4125-b8cb-ed48d6adf25c" />


### **이슈번호 #279  **
